### PR TITLE
ci: skip changeset status check on the changesets release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,9 @@ jobs:
       - name: Build, lint, typecheck, and test
         run: pnpm exec turbo run build lint typecheck test test:e2e
 
+      # Skip on the changesets "Version Packages" PR (branch changeset-release/main):
+      # it intentionally has no changeset (it consumed them to bump versions), so the
+      # contributor-facing gate would always fail there. Build/lint/test still run.
       - name: Check changeset status
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
         run: pnpm exec changeset status --since=origin/main


### PR DESCRIPTION
The "Version Packages" PR opened by changesets/action (branch changeset-release/main) consumes the changeset files to bump versions, so the contributor-facing `changeset status` gate always fails on it and blocks the release. Skip just that step for changeset-release/* branches; build, lint, typecheck and test still run on the version bump.