### PR TITLE
fix(skills): make hooks fire correctly, validate gate CI, and sync resolve skills

### DIFF
--- a/.changeset/auto-skills-validate-and-hook-payloads.md
+++ b/.changeset/auto-skills-validate-and-hook-payloads.md
@@ -1,0 +1,90 @@
+---
+"@satoshibits/create-auto-loading-claude-skills": major
+---
+
+Make `validate` catch broken rules, and switch on the pre-tool guardrails that never fired.
+
+**BREAKING — `validate` now fails on errors.** It previously printed problems and always
+exited 0, so it could never gate a commit or CI job. Three previously-ignored mistakes are
+now errors: missing required fields (`type`, `enforcement`, `priority`, `description`), an
+`activationStrategy` outside the enum, and (as warnings) unknown fields. Each of these
+silently disabled the skill at runtime — an unrecognized `activationStrategy` falls through
+to `native_only`, and a rule missing required fields is scored but never displayed. A config
+that "passed" before may now fail; that is the point. `validate --fix` exits non-zero when
+errors remain, based on **what auto-fix actually repaired** — its prompts are interactive,
+so with stdin closed (any CI runner) they abort and nothing is fixed. It also registers the
+`-v, --verbose` flag it had always advertised but never defined; passing it previously
+failed as an unknown option.
+
+**Guardrails that never fired now can.** Note `init` registers only `UserPromptSubmit`,
+`PostToolUse` and `Stop` hooks — not `PreToolUse` or `SessionStart` — so neither validator
+template nor `session-start` runs in a default install; wire them into `settings.json`
+manually to use `preToolTriggers` or session-start context. Both `PreToolUse` templates
+typed `tool_input` as `string`; Claude Code sends an object, so every `inputPatterns` rule silently matched
+nothing. They now pass it through as `unknown` (see the runtime changelog for the matching
+semantics). **If you have `preToolTriggers.inputPatterns` rules, they will begin matching
+for the first time** — review them before upgrading. Patterns are tested against each string
+field of the tool input, so a pattern may now also match non-command fields such as Claude's
+own `description`.
+
+**User-scope rules.** All seven hook templates opt into the runtime's `userScope`, so
+personal skills in `~/.claude/skills` participate in every hook rather than only prompt
+activation — enabling it on the activation hooks alone would surface a user-level guardrail
+as a suggestion that never actually fired at `PreToolUse`. Content stays scope-isolated: a
+project config cannot cause a user-scope `SKILL.md` to be read.
+
+**BREAKING — `sync` no longer copies personal skills into a project config.** Running
+`sync` inside a project previously wrote your `~/.claude/skills` rules into that project's
+`skill-rules.yaml`. With scope-isolated content resolution those copies are unusable — they
+point at `<project>/.claude/skills/<name>/SKILL.md`, which does not exist — and because
+project rules win collisions they also shadow the working user-scope entry, so
+`sync && validate` would report an orphaned-skill error for every personal skill. Sync
+personal skills from your home directory instead (`cd ~ && cl-auto-skills sync`), which
+writes `~/.claude/skills/skill-rules.yaml` where the runtime can resolve them.
+`sync-status` applies the same scope rule, so it no longer reports "stale" immediately
+after a clean sync.
+
+**BREAKING — `sync` reads project skills from `.claude/skills/`, not `.claude/commands/`.**
+It previously scanned only `.claude/commands/`, while `init`, `validate` and the runtime
+all resolve `.claude/skills/<name>/SKILL.md` — so a skill authored in the documented
+location was invisible to `sync`, and one authored under `commands/` synced into a rule
+that `validate` reported as orphaned and the runtime could never load. `sync` now reads
+`.claude/skills/` and prints a notice if it finds `SKILL.md` files left under
+`commands/`; move them to `.claude/skills/<name>/SKILL.md`.
+
+**Migration:** `sync` now removes entries it previously wrote whose `SKILL.md` no longer
+exists — including personal skills an older release copied into a project config. Without
+this, deleting your last skill left the config permanently stale with no way to repair it,
+and the stale personal copies kept shadowing the real user-scope skills.
+
+**`validate --fix` gains `-y, --yes`** to apply repairs unattended. Without it, `--fix` on
+a non-TTY stdin now refuses and exits non-zero rather than aborting inside the prompt and
+exiting 0 having repaired nothing. A run that fully repairs the config exits 0. A `skills:`
+block that is not a mapping is reported as an error and `--fix` refuses to touch the file,
+rather than rewriting it and discarding the malformed block.
+
+The `PreToolUse` text template no longer prints "TOOL EXECUTION BLOCKED". It exits 0 and
+cannot block; the banner was unreachable before (no `inputPatterns` ever matched) and would
+now be actively misleading. It reports an advisory guardrail hit and points at the `-json`
+variant, which can deny.
+
+**Crash fixes.** A config that omits the `skills:` block, sets it to a scalar or array, or
+contains a bare `my-skill:` entry that YAML parses as null, previously crashed `validate`
+with a `TypeError`. All are now reported as ordinary findings, and a malformed
+rule is no longer silently deleted from your file by `--fix` while the output tells you to
+fix it by hand. An empty `keywords: []` alongside real `intentPatterns`
+is no longer misreported as "no triggers defined" (a `??` that short-circuited on `false`).
+
+**Payload shape.** Templates accept the current `cwd` field with `working_directory` still
+honored. This is defensive: Claude Code sets `CLAUDE_PROJECT_DIR` when spawning hooks
+(verified against a live invocation), so the payload fields are a fallback, not the primary
+resolution path.
+
+Tests: hook assertions now check **observable output** per hook (suggestions emitted,
+guardrail matched, session state written, skills counted) instead of `exitCode === 0` —
+every hook fails open by design, so "did not crash" was satisfied by a hook that resolved
+nothing. Each case is paired with a negative control, and removing the legacy fallback turns
+exactly the legacy-payload cases red. The compiled-hook runner now pins `HOME`/`USERPROFILE`
+to a temp dir so a developer's real `~/.claude` cannot leak into results. Several fixtures
+that claimed to be valid configurations were missing required fields or `SKILL.md` files,
+and three assertions passed on substring coincidence with the skill's own name.

--- a/.changeset/skill-runtime-cwd-and-user-scope.md
+++ b/.changeset/skill-runtime-cwd-and-user-scope.md
@@ -1,0 +1,38 @@
+---
+"@satoshibits/claude-skill-runtime": minor
+---
+
+Fix pre-tool guardrail matching, add opt-in user-scope rules, and accept current hook
+payload shapes.
+
+**`inputPatterns` guardrails never matched anything.** `RuleMatcher.matchPreToolTriggers`
+typed its input as `string`, but Claude Code sends `tool_input` as an object
+(`{ command: "rm -rf /" }`). `RegExp.test` coerced that to `"[object Object]"`, so no
+`preToolTriggers.inputPatterns` rule could ever fire. It now accepts `unknown` and tests
+patterns against each **string leaf value separately**, rather than a JSON dump of the
+object: a dump breaks anchored patterns (`^rm ` cannot match a subject beginning `{"`) and
+would let key names and JSON escaping match. Serialization is deferred and memoized, so a
+large `Write`/`Edit` payload is not walked on every tool call in projects whose rules never
+inspect the input. Cycles are guarded.
+
+**User-scope rules (`{ userScope }`, default off).** `ConfigLoader` can also load
+`~/.claude/skills/skill-rules.yaml` (resolved via `os.homedir()`) and merge it beneath
+project rules: project wins on skill-name collision, and `settings` merge key by key with
+project precedence (`scoring`/`thresholds` one level deeper), so a project that sets a
+single key no longer discards the user's global preferences.
+
+Content resolution is **scope-isolated**: a skill's `SKILL.md` is only read from the scope
+that declared the rule. A project's `skill-rules.yaml` arrives with any cloned repository
+and is untrusted data, so a cross-scope search would let it name a user-scope skill and
+have the hook read and print a private file out of `$HOME`. Skill names containing path
+separators or `..` are rejected. An **unparseable** project config degrades to the empty
+default rather than silently inheriting the entire user rule set; an **absent** one still
+merges user scope.
+
+**Payload shape.** `initHookContext` accepts `cwd` and resolves
+`CLAUDE_PROJECT_DIR ?? cwd ?? workingDirectory ?? process.cwd()`; `resolveHookDir(data)`
+reads `cwd` with a `working_directory` fallback. Note this is defensive rather than a fix
+for an observed production failure: Claude Code sets `CLAUDE_PROJECT_DIR` when it spawns a
+hook (verified against a live invocation), so the payload fields are the fallback path.
+They matter for harnesses and tests that invoke hooks directly, and for any invocation
+where the variable is absent.

--- a/packages/claude-skill-runtime/src/__tests__/config-loader.test.mts
+++ b/packages/claude-skill-runtime/src/__tests__/config-loader.test.mts
@@ -291,6 +291,19 @@ skills:
       const loader = new ConfigLoader(tmpDir);
       expect(loader.skillExists('missing-skill')).toBe(false);
     });
+
+    it('resolves a lowercase skill.md (matches case-insensitive discovery)', () => {
+      // skills are discovered with a nocase glob; on a case-sensitive filesystem a
+      // lowercase skill.md would sync and validate cleanly but never load its content if
+      // the resolver were uppercase-only
+      const dir = path.join(tmpDir, '.claude', 'skills', 'lower-skill');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'skill.md'), '# lowercase content');
+
+      const loader = new ConfigLoader(tmpDir);
+      expect(loader.skillExists('lower-skill')).toBe(true);
+      expect(loader.loadSkillContent('lower-skill')).toContain('lowercase content');
+    });
   });
 
   describe('getLogger()', () => {
@@ -326,5 +339,282 @@ skills:
       const logPath = path.join(cacheDir, 'debug.log');
       expect(fs.existsSync(logPath)).toBe(true);
     });
+  });
+});
+
+describe('config-loader user scope', () => {
+  let projectDir: string;
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let originalDebug: string | undefined;
+
+  beforeEach(() => {
+    projectDir = createTempDir('user-scope-project-');
+    homeDir = createTempDir('user-scope-home-');
+    // os.homedir() honors $HOME on POSIX, so this redirects ~/.claude for the test
+    originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    originalDebug = process.env.DEBUG;
+    delete process.env.DEBUG;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalDebug !== undefined) process.env.DEBUG = originalDebug;
+    cleanupTempDir(projectDir);
+    cleanupTempDir(homeDir);
+  });
+
+  const rule = (description: string) => ({
+    type: 'domain' as const,
+    enforcement: 'suggest' as const,
+    priority: 'high' as const,
+    description,
+    activationStrategy: 'suggestive' as const,
+    promptTriggers: { keywords: ['thing'] },
+  });
+
+  it('ignores user rules by default (unchanged behavior)', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+    createSkillRulesYaml(projectDir, { skills: { 'proj-skill': rule('from project') } });
+
+    const config = new ConfigLoader(projectDir).loadSkillRules();
+
+    expect(Object.keys(config.skills)).toEqual(['proj-skill']);
+  });
+
+  it('merges user rules beneath project rules when enabled', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+    createSkillRulesYaml(projectDir, { skills: { 'proj-skill': rule('from project') } });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(Object.keys(config.skills).sort()).toEqual(['proj-skill', 'user-skill']);
+  });
+
+  it('project wins on skill-name collision', () => {
+    createSkillRulesYaml(homeDir, { skills: { shared: rule('from user') } });
+    createSkillRulesYaml(projectDir, { skills: { shared: rule('from project') } });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(config.skills.shared?.description).toBe('from project');
+  });
+
+  it('loads user rules when the project has none', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(config.skills['user-skill']?.description).toBe('from user');
+  });
+
+  it('degrades to project-only when the user file is malformed', () => {
+    const userSkillsDir = path.join(homeDir, '.claude', 'skills');
+    fs.mkdirSync(userSkillsDir, { recursive: true });
+    fs.writeFileSync(path.join(userSkillsDir, 'skill-rules.yaml'), 'skills: [unclosed\n');
+    createSkillRulesYaml(projectDir, { skills: { 'proj-skill': rule('from project') } });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(Object.keys(config.skills)).toEqual(['proj-skill']);
+  });
+
+  it('resolves content from the scope that DECLARED each skill', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+    createSkill(homeDir, 'user-skill', '# user version');
+    createSkill(homeDir, 'shared', '# user shared');
+    createSkillRulesYaml(projectDir, { skills: { shared: rule('from project') } });
+    createSkill(projectDir, 'shared', '# project shared');
+
+    const loader = new ConfigLoader(projectDir, { userScope: true });
+
+    // user-declared rule resolves under ~/.claude even without an explicit
+    // loadSkillRules() call first — the scope map populates on demand
+    expect(loader.skillExists('user-skill')).toBe(true);
+    expect(loader.loadSkillContent('user-skill')).toContain('user version');
+    // project declared `shared`, so the project copy wins
+    expect(loader.loadSkillContent('shared')).toContain('project shared');
+    expect(loader.skillExists('nope')).toBe(false);
+  });
+
+  it('does not merge a directory with itself when the project IS ~/.claude', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+
+    const config = new ConfigLoader(homeDir, { userScope: true }).loadSkillRules();
+
+    expect(Object.keys(config.skills)).toEqual(['user-skill']);
+  });
+});
+
+describe('config-loader user/project settings merge', () => {
+  let projectDir: string;
+  let homeDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    projectDir = createTempDir('settings-merge-project-');
+    homeDir = createTempDir('settings-merge-home-');
+    originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    cleanupTempDir(projectDir);
+    cleanupTempDir(homeDir);
+  });
+
+  it('keeps user settings the project does not override', () => {
+    // a project that sets only one key must not wipe the user's global preferences
+    createSkillRulesYaml(homeDir, {
+      settings: {
+        maxSuggestions: 1,
+        enableDebugLogging: false,
+        thresholds: { recentActivationMinutes: 60 },
+      },
+      skills: {},
+    });
+    createSkillRulesYaml(projectDir, {
+      settings: { enableDebugLogging: true },
+      skills: {},
+    });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(config.settings?.enableDebugLogging).toBe(true); // project wins
+    expect(config.settings?.maxSuggestions).toBe(1); // user preserved
+    expect(config.settings?.thresholds?.recentActivationMinutes).toBe(60);
+  });
+
+  it('merges nested scoring keys with project precedence', () => {
+    createSkillRulesYaml(homeDir, {
+      settings: { scoring: { keywordMatchScore: 99, intentPatternScore: 88 } },
+      skills: {},
+    });
+    createSkillRulesYaml(projectDir, {
+      settings: { scoring: { keywordMatchScore: 5 } },
+      skills: {},
+    });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(config.settings?.scoring?.keywordMatchScore).toBe(5); // project wins
+    expect(config.settings?.scoring?.intentPatternScore).toBe(88); // user preserved
+  });
+});
+
+describe('config-loader scope isolation (security)', () => {
+  let projectDir: string;
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeEach(() => {
+    projectDir = createTempDir('scope-isolation-project-');
+    homeDir = createTempDir('scope-isolation-home-');
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    // os.homedir() reads USERPROFILE on win32 and HOME on POSIX — set both
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    cleanupTempDir(projectDir);
+    cleanupTempDir(homeDir);
+  });
+
+  const rule = (description: string) => ({
+    type: 'domain' as const,
+    enforcement: 'suggest' as const,
+    priority: 'high' as const,
+    description,
+    activationStrategy: 'suggestive' as const,
+    promptTriggers: { keywords: ['thing'] },
+  });
+
+  it('does NOT let a project rule read a user-scope skill file', () => {
+    // a cloned repo's skill-rules.yaml is untrusted data; if it could name a user skill,
+    // the hook would read and print a private file out of $HOME
+    createSkill(homeDir, 'private-notes', '# SECRET user content');
+    createSkillRulesYaml(projectDir, { skills: { 'private-notes': rule('claimed by project') } });
+
+    const loader = new ConfigLoader(projectDir, { userScope: true });
+    loader.loadSkillRules();
+
+    expect(loader.skillExists('private-notes')).toBe(false);
+    expect(loader.loadSkillContent('private-notes')).toBeNull();
+  });
+
+  it('still resolves a user-scope skill that the USER declared', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'my-skill': rule('declared by user') } });
+    createSkill(homeDir, 'my-skill', '# user content');
+
+    const loader = new ConfigLoader(projectDir, { userScope: true });
+    loader.loadSkillRules();
+
+    expect(loader.skillExists('my-skill')).toBe(true);
+    expect(loader.loadSkillContent('my-skill')).toContain('user content');
+  });
+
+  it('resolves the project copy when both scopes declare the same name', () => {
+    createSkillRulesYaml(homeDir, { skills: { shared: rule('user') } });
+    createSkill(homeDir, 'shared', '# user copy');
+    createSkillRulesYaml(projectDir, { skills: { shared: rule('project') } });
+    createSkill(projectDir, 'shared', '# project copy');
+
+    const loader = new ConfigLoader(projectDir, { userScope: true });
+    loader.loadSkillRules();
+
+    expect(loader.loadSkillContent('shared')).toContain('project copy');
+  });
+
+  it('rejects traversal even when the traversed-to SKILL.md really exists', () => {
+    // plant a file that IS reachable by traversal, so the guard is the only thing
+    // stopping the read — asserting on non-existent paths would pass with no guard at all
+    const reachable = path.join(projectDir, '.claude', 'evil');
+    fs.mkdirSync(reachable, { recursive: true });
+    fs.writeFileSync(path.join(reachable, 'SKILL.md'), '# REACHED');
+
+    const loader = new ConfigLoader(projectDir, { userScope: true });
+    loader.loadSkillRules();
+
+    expect(loader.loadSkillContent('../evil')).toBeNull();
+    expect(loader.skillExists('../evil')).toBe(false);
+    expect(loader.loadSkillContent('/etc/passwd')).toBeNull();
+
+    // control: the same content IS readable when reached legitimately, proving the
+    // fixture is live and the nulls above come from the guard, not a missing file
+    fs.cpSync(reachable, path.join(projectDir, '.claude', 'skills', 'evil'), {
+      recursive: true,
+    });
+    expect(loader.loadSkillContent('evil')).toContain('REACHED');
+  });
+
+  it('an UNPARSEABLE project file degrades to empty, not to the user rule set', () => {
+    // a project typo must not silently swap in a different set of active skills
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+    const projectSkills = path.join(projectDir, '.claude', 'skills');
+    fs.mkdirSync(projectSkills, { recursive: true });
+    fs.writeFileSync(path.join(projectSkills, 'skill-rules.yaml'), 'skills: [unclosed\n');
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(Object.keys(config.skills)).toEqual([]);
+  });
+
+  it('an ABSENT project file still merges user scope', () => {
+    createSkillRulesYaml(homeDir, { skills: { 'user-skill': rule('from user') } });
+
+    const config = new ConfigLoader(projectDir, { userScope: true }).loadSkillRules();
+
+    expect(Object.keys(config.skills)).toEqual(['user-skill']);
   });
 });

--- a/packages/claude-skill-runtime/src/__tests__/helpers.ts
+++ b/packages/claude-skill-runtime/src/__tests__/helpers.ts
@@ -197,6 +197,10 @@ function generateYaml(obj: unknown, indent = 0): string {
     if (entries.length === 0) return '{}';
     return entries.map(([key, value]) => {
       if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        // an empty object must stay inline (`key: {}`). Emitting `key:` and then `{}` on
+        // the next line at the parent indent is unparseable YAML, and the loader then
+        // silently degrades to defaults — mirrors the empty-array case just below.
+        if (Object.keys(value as object).length === 0) return `${spaces}${key}: {}`;
         return `${spaces}${key}:\n${generateYaml(value, indent + 1)}`;
       }
       if (Array.isArray(value)) {

--- a/packages/claude-skill-runtime/src/__tests__/hook-output.test.mts
+++ b/packages/claude-skill-runtime/src/__tests__/hook-output.test.mts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildPreToolUseAllowOutput,
+  buildPreToolUseContextOutput,
+  buildPreToolUseDenyOutput,
+} from "../hook-output.mjs";
+
+/**
+ * Unit-level guards for the PreToolUse permission builders.
+ *
+ * These are deliberately at the unit level: a security property this important should not
+ * depend on spawning a compiled hook binary that a concurrent process could perturb. The
+ * core invariant is that a NON-blocking advisory (a `warn` guardrail) must never emit a
+ * permission decision — emitting `"allow"` would grant the tool call.
+ */
+describe("PreToolUse permission builders", () => {
+  it("context output adds additionalContext with NO permissionDecision", () => {
+    const out = buildPreToolUseContextOutput("some warning");
+    expect(out.hookSpecificOutput?.additionalContext).toBe("some warning");
+    expect(
+      (out.hookSpecificOutput as { permissionDecision?: string } | undefined)
+        ?.permissionDecision,
+    ).toBeUndefined();
+  });
+
+  it("context output is empty (no decision) when there is nothing to say", () => {
+    expect(buildPreToolUseContextOutput()).toEqual({});
+    expect(buildPreToolUseContextOutput("")).toEqual({});
+  });
+
+  it("allow output DOES grant — kept distinct from context output on purpose", () => {
+    const out = buildPreToolUseAllowOutput("ctx");
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("allow");
+  });
+
+  it("deny output blocks with a reason", () => {
+    const out = buildPreToolUseDenyOutput("nope");
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+});

--- a/packages/claude-skill-runtime/src/__tests__/hook-utils.test.mts
+++ b/packages/claude-skill-runtime/src/__tests__/hook-utils.test.mts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { readStdin, initHookContext, handleHookError } from '../hook-utils.mjs';
+import { readStdin, initHookContext, handleHookError, resolveHookDir } from '../hook-utils.mjs';
 import { createTempDir, cleanupTempDir, createSkillRulesYaml } from './helpers.js';
 
 describe('hook-utils', () => {
@@ -253,5 +253,51 @@ describe('hook-utils', () => {
         })
       ).not.toThrow();
     });
+  });
+});
+
+describe('resolveHookDir + directory precedence', () => {
+  let originalProjectDir: string | undefined;
+
+  beforeEach(() => {
+    originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+
+  afterEach(() => {
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+  });
+
+  it.each([
+    ['cwd only (current payload shape)', { cwd: '/a' }, '/a'],
+    ['working_directory only (legacy shape)', { working_directory: '/b' }, '/b'],
+    ['cwd wins when both present', { cwd: '/a', working_directory: '/b' }, '/a'],
+    ['neither field', {}, undefined],
+  ])('%s', (_label, payload, expected) => {
+    expect(resolveHookDir(payload)).toBe(expected);
+  });
+
+  it('returns undefined for a missing payload', () => {
+    expect(resolveHookDir(undefined)).toBeUndefined();
+  });
+
+  it('prefers CLAUDE_PROJECT_DIR over the payload, then payload, then process.cwd()', () => {
+    const tmp = createTempDir('precedence-');
+    try {
+      // env wins
+      process.env.CLAUDE_PROJECT_DIR = tmp;
+      expect(initHookContext({ cwd: '/ignored' }).projectDir).toBe(tmp);
+
+      // payload wins when env is absent
+      delete process.env.CLAUDE_PROJECT_DIR;
+      expect(initHookContext({ cwd: tmp }).projectDir).toBe(tmp);
+      expect(initHookContext({ workingDirectory: tmp }).projectDir).toBe(tmp);
+
+      // last resort: never undefined, so path.join can't throw
+      expect(initHookContext({}).projectDir).toBe(process.cwd());
+    } finally {
+      cleanupTempDir(tmp);
+    }
   });
 });

--- a/packages/claude-skill-runtime/src/__tests__/rule-matcher.test.mts
+++ b/packages/claude-skill-runtime/src/__tests__/rule-matcher.test.mts
@@ -324,6 +324,101 @@ describe('rule-matcher', () => {
       expect(matches[0]!.matchedPattern).toBe('git.*push.*--force');
     });
 
+    it('matches input patterns when tool_input is an OBJECT (real payload shape)', () => {
+      // Claude Code sends tool_input as an object. Passing it to RegExp.test coerced it to
+      // "[object Object]", so every inputPatterns guardrail silently failed to match.
+      const config = createMinimalConfig({
+        'git-push-guard': {
+          ...defaultSkillRule,
+          preToolTriggers: {
+            toolName: 'Bash',
+            inputPatterns: ['git.*push.*--force'],
+          },
+        },
+      });
+
+      const matcher = new RuleMatcher(config, tmpDir);
+      const matches = matcher.matchPreToolTriggers('Bash', {
+        command: 'git push --force origin main',
+        description: 'force push',
+      });
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.matchedPattern).toBe('git.*push.*--force');
+    });
+
+    it('preserves anchored patterns against object input', () => {
+      // a JSON dump of the object would start with `{"`, so `^ls` could never match
+      const config = createMinimalConfig({
+        'ls-guard': {
+          ...defaultSkillRule,
+          preToolTriggers: { toolName: 'Bash', inputPatterns: ['^ls'] },
+        },
+      });
+      const matcher = new RuleMatcher(config, tmpDir);
+
+      expect(
+        matcher.matchPreToolTriggers('Bash', { command: 'ls -la' }),
+      ).toHaveLength(1);
+      expect(
+        matcher.matchPreToolTriggers('Bash', { command: 'echo ls' }),
+      ).toHaveLength(0);
+    });
+
+    it('does not coerce non-string leaves into match subjects', () => {
+      // `^false$` must not fire on `{ sandbox: false }` — patterns are written against
+      // user-authored text, so only string leaves are subjects
+      const config = createMinimalConfig({
+        'bool-guard': {
+          ...defaultSkillRule,
+          preToolTriggers: { toolName: 'Bash', inputPatterns: ['^false$', '^42$'] },
+        },
+      });
+      const matcher = new RuleMatcher(config, tmpDir);
+
+      expect(
+        matcher.matchPreToolTriggers('Bash', { sandbox: false, timeout: 42 }),
+      ).toHaveLength(0);
+      // control: the same pattern DOES match when the value is genuinely a string
+      expect(
+        matcher.matchPreToolTriggers('Bash', { command: 'false' }),
+      ).toHaveLength(1);
+    });
+
+    it('does not match against object KEY names', () => {
+      // key names are not user content; matching them produces phantom guardrail hits
+      const config = createMinimalConfig({
+        'command-guard': {
+          ...defaultSkillRule,
+          preToolTriggers: { toolName: 'Bash', inputPatterns: ['command'] },
+        },
+      });
+      const matcher = new RuleMatcher(config, tmpDir);
+
+      expect(
+        matcher.matchPreToolTriggers('Bash', { command: 'ls -la' }),
+      ).toHaveLength(0);
+    });
+
+    it('does not throw on null/undefined/circular tool input', () => {
+      const config = createMinimalConfig({
+        'bash-guard': {
+          ...defaultSkillRule,
+          preToolTriggers: { toolName: 'Bash', inputPatterns: ['rm'] },
+        },
+      });
+      const matcher = new RuleMatcher(config, tmpDir);
+
+      const circular: Record<string, unknown> = { command: 'rm -rf /' };
+      circular.self = circular;
+
+      // only the circular case is falsifiable here — it pins the cycle guard in
+      // collectStrings, which would otherwise recurse until the stack blows
+      expect(() => matcher.matchPreToolTriggers('Bash', circular)).not.toThrow();
+      expect(matcher.matchPreToolTriggers('Bash', circular)).toHaveLength(1);
+      expect(matcher.matchPreToolTriggers('Bash', null)).toHaveLength(0);
+    });
+
     it('does not match when tool name differs', () => {
       const config = createMinimalConfig({
         'bash-only': {

--- a/packages/claude-skill-runtime/src/config-loader.mts
+++ b/packages/claude-skill-runtime/src/config-loader.mts
@@ -5,6 +5,7 @@
 
 import yaml from "js-yaml";
 import fs from "fs";
+import os from "os";
 import path from "path";
 
 import type { DebugLogger, SkillConfig } from "./types.mjs";
@@ -43,49 +44,103 @@ export function createDefaultConfig(): SkillConfig {
  * Load and parse skill rules configuration
  * Supports both JSON and YAML formats
  */
+/**
+ * Merge user-scope settings with project-scope settings, key by key.
+ *
+ * Replacing the whole block when a project defines any settings would silently drop a
+ * user's global preferences: a project setting only `enableDebugLogging` would wipe their
+ * `maxSuggestions` and thresholds. Nested `scoring` / `thresholds` are merged one level
+ * deeper for the same reason. Project values win on every conflict.
+ */
+function mergeSettings(
+  user: SkillConfig["settings"] | undefined,
+  project: SkillConfig["settings"] | undefined,
+): SkillConfig["settings"] | undefined {
+  if (!user) return project;
+  if (!project) return user;
+
+  return {
+    ...user,
+    ...project,
+    ...(user.scoring || project.scoring
+      ? { scoring: { ...user.scoring, ...project.scoring } }
+      : {}),
+    ...(user.thresholds || project.thresholds
+      ? { thresholds: { ...user.thresholds, ...project.thresholds } }
+      : {}),
+  } as SkillConfig["settings"];
+}
+
+export interface ConfigLoaderOptions {
+  /**
+   * Also read user-level rules from ~/.claude/skills/ and merge them beneath project rules.
+   * Default false, so existing project-only behavior is unchanged.
+   */
+  userScope?: boolean;
+}
+
+/** Outcome of reading one scope's skill-rules file. */
+type ScopeLoad =
+  | { status: "ok"; config: SkillConfig }
+  | { status: "absent" }
+  | { status: "error" };
+
 export class ConfigLoader {
   private skillsDir: string;
+  /** User-level skills dir (~/.claude/skills), set only when userScope is enabled. */
+  private userSkillsDir: string | null = null;
+  /**
+   * Which scope declared each skill. Content is resolved ONLY from the declaring scope:
+   * a project's skill-rules.yaml arrives with any cloned repo and is data, not reviewed
+   * code, so letting it name a user-scope skill would let it read files out of $HOME.
+   */
+  private skillScopes = new Map<string, "project" | "user">();
+  /**
+   * Whether the scope map reflects a completed load. An EMPTY map is ambiguous — a config
+   * with zero skills looks the same as "never loaded" — so `findSkillPath` used the size
+   * alone and re-read both files on every call in the zero-skill case. This flag settles it.
+   */
+  private scopesLoaded = false;
 
-  constructor(projectDir: string) {
+  constructor(projectDir: string, options: ConfigLoaderOptions = {}) {
     this.skillsDir = path.join(projectDir, ".claude", "skills");
+
+    if (options.userScope) {
+      // resolve ~ explicitly — fs does not expand it
+      const userSkillsDir = path.join(os.homedir(), ".claude", "skills");
+      // skip when the project IS ~/.claude, so the same file isn't merged with itself
+      if (path.resolve(userSkillsDir) !== path.resolve(this.skillsDir)) {
+        this.userSkillsDir = userSkillsDir;
+      }
+    }
   }
 
   /**
    * Load skill-rules from either YAML or JSON
    * Returns default empty config if files don't exist or are invalid (graceful degradation)
+   *
+   * With userScope enabled, user rules load first and project rules are merged on top:
+   * project wins on skill-name collision, and `settings` merge key by key with project
+   * precedence (see mergeSettings).
+   *
+   * An UNPARSEABLE project file degrades to the empty default rather than silently
+   * inheriting the entire user rule set — a typo in a project config must not swap in a
+   * different set of active skills. An ABSENT project file is a normal "no project rules"
+   * case and does merge user scope.
    */
   loadSkillRules(): SkillConfig {
-    const yamlPath = path.join(this.skillsDir, "skill-rules.yaml");
-    const jsonPath = path.join(this.skillsDir, "skill-rules.json");
+    this.skillScopes.clear();
+    this.scopesLoaded = true;
 
-    if (fs.existsSync(yamlPath)) {
-      try {
-        const config = this.loadYAML(yamlPath);
-        return this.ensureValidConfig(config);
-      } catch (error) {
-        // gracefully fall back to default config on parse error
-        if (process.env.DEBUG) {
-          console.warn(
-            `⚠️  Failed to parse skill-rules.yaml, using default config: ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-        return this.getDefaultConfig();
-      }
-    } else if (fs.existsSync(jsonPath)) {
-      try {
-        const config = this.loadJSON(jsonPath);
-        return this.ensureValidConfig(config);
-      } catch (error) {
-        // gracefully fall back to default config on parse error
-        if (process.env.DEBUG) {
-          console.warn(
-            `⚠️  Failed to parse skill-rules.json, using default config: ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-        return this.getDefaultConfig();
-      }
-    } else {
-      // gracefully return empty config if no files found
+    const project = this.loadConfigFrom(this.skillsDir);
+    const user = this.userSkillsDir
+      ? this.loadConfigFrom(this.userSkillsDir)
+      : ({ status: "absent" } as ScopeLoad);
+
+    // a broken project file is a hard stop for merging: degrade to empty, not to user rules
+    if (project.status === "error") return this.getDefaultConfig();
+
+    if (project.status === "absent" && user.status !== "ok") {
       if (process.env.DEBUG) {
         console.warn(
           "⚠️  No skill-rules.yaml or skill-rules.json found, using empty config",
@@ -93,6 +148,65 @@ export class ConfigLoader {
       }
       return this.getDefaultConfig();
     }
+
+    const projectConfig =
+      project.status === "ok" ? this.ensureValidConfig(project.config) : null;
+    const userConfig =
+      user.status === "ok" ? this.ensureValidConfig(user.config) : null;
+
+    for (const name of Object.keys(userConfig?.skills ?? {})) {
+      this.skillScopes.set(name, "user");
+    }
+    for (const name of Object.keys(projectConfig?.skills ?? {})) {
+      this.skillScopes.set(name, "project"); // project wins the collision
+    }
+
+    if (!userConfig) return this.ensureValidConfig(projectConfig);
+    if (!projectConfig) return this.ensureValidConfig(userConfig);
+
+    return this.ensureValidConfig({
+      ...userConfig,
+      ...projectConfig,
+      // ensureValidConfig fills a placeholder description, so a project that never set
+      // one would otherwise overwrite the user's real description with it
+      description:
+        (projectConfig.description === "Skill rules configuration"
+          ? userConfig.description
+          : projectConfig.description) ?? userConfig.description,
+      settings: mergeSettings(userConfig.settings, projectConfig.settings),
+      skills: { ...userConfig.skills, ...projectConfig.skills },
+    });
+  }
+
+  /**
+   * Load a skill-rules file from one directory, YAML preferred over JSON.
+   *
+   * Distinguishes "no file" from "file present but unparseable" — the caller must be able
+   * to treat a broken config differently from an absent one.
+   */
+  private loadConfigFrom(dir: string): ScopeLoad {
+    const candidates: [string, (p: string) => SkillConfig | undefined][] = [
+      [path.join(dir, "skill-rules.yaml"), (p) => this.loadYAML(p)],
+      [path.join(dir, "skill-rules.json"), (p) => this.loadJSON(p)],
+    ];
+
+    for (const [filePath, load] of candidates) {
+      if (!fs.existsSync(filePath)) continue;
+      try {
+        const config = load(filePath);
+        // an empty file parses to undefined; treat it as "present but says nothing"
+        return config ? { status: "ok", config } : { status: "absent" };
+      } catch (error) {
+        if (process.env.DEBUG) {
+          console.warn(
+            `⚠️  Failed to parse ${path.basename(filePath)} in ${dir}, ignoring it: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        return { status: "error" };
+      }
+    }
+
+    return { status: "absent" };
   }
 
   /**
@@ -112,9 +226,28 @@ export class ConfigLoader {
 
     const cfg = config as Record<string, unknown>;
 
-    // ensure skills object exists
-    if (!cfg.skills || typeof cfg.skills !== "object") {
+    // ensure skills is a mapping. Array.isArray matters: a YAML sequence would otherwise
+    // be iterated as rules named "0", "1", … — and validate rejects it, so the two must
+    // agree on the shape they accept.
+    if (
+      !cfg.skills ||
+      typeof cfg.skills !== "object" ||
+      Array.isArray(cfg.skills)
+    ) {
       cfg.skills = {};
+    }
+
+    // a bare `my-skill:` entry parses to null; every consumer immediately reads
+    // properties off the rule, so drop malformed entries here rather than crashing
+    // the hook that loaded them
+    const skills = cfg.skills as Record<string, unknown>;
+    for (const [name, rule] of Object.entries(skills)) {
+      if (!rule || typeof rule !== "object") {
+        if (process.env.DEBUG) {
+          console.warn(`⚠️  Skill '${name}' has no configuration, ignoring it`);
+        }
+        delete skills[name];
+      }
     }
 
     // ensure required fields exist
@@ -127,32 +260,31 @@ export class ConfigLoader {
   /**
    * Load JSON configuration
    */
-  private loadJSON(filePath: string): SkillConfig {
+  private loadJSON(filePath: string): SkillConfig | undefined {
     const content = fs.readFileSync(filePath, "utf8");
-    return JSON.parse(content) as SkillConfig;
+    return JSON.parse(content) as SkillConfig | undefined;
   }
 
   /**
    * Load YAML configuration
    */
-  private loadYAML(filePath: string): SkillConfig {
+  private loadYAML(filePath: string): SkillConfig | undefined {
     const content = fs.readFileSync(filePath, "utf8");
     // use JSON_SCHEMA for safe deserialization (no arbitrary object instantiation)
-    return yaml.load(content, { schema: yaml.JSON_SCHEMA }) as SkillConfig;
+    // note: an empty document yields undefined, not an object
+    return yaml.load(content, { schema: yaml.JSON_SCHEMA }) as SkillConfig | undefined;
   }
 
   /**
    * Load skill content (returns null for graceful degradation)
    */
   loadSkillContent(skillName: string): string | null {
-    const skillPath = path.join(this.skillsDir, skillName, "SKILL.md");
+    const skillPath = this.findSkillPath(skillName);
 
-    if (!fs.existsSync(skillPath)) {
+    if (!skillPath) {
       // graceful degradation - return null instead of throwing
       if (process.env.DEBUG) {
-        console.warn(
-          `⚠️  Warning: Skill '${skillName}' not found at ${skillPath}`,
-        );
+        console.warn(`⚠️  Warning: Skill '${skillName}' not found in its declaring scope`);
       }
       return null;
     }
@@ -161,11 +293,55 @@ export class ConfigLoader {
   }
 
   /**
-   * Check if skill exists
+   * Check if the skill's SKILL.md exists in the scope that declared it
    */
   skillExists(skillName: string): boolean {
-    const skillPath = path.join(this.skillsDir, skillName, "SKILL.md");
-    return fs.existsSync(skillPath);
+    return this.findSkillPath(skillName) !== null;
+  }
+
+  /**
+   * Resolve a skill's SKILL.md **in the scope that declared the rule**.
+   *
+   * Deliberately not a search across scopes. A project's skill-rules.yaml is untrusted
+   * data that arrives with any cloned repo, so if it could name a user-scope skill the
+   * hook would read and print a private file out of $HOME. A rule declared by the project
+   * resolves only under the project; a rule declared by the user resolves only under
+   * ~/.claude. Names absent from the merged config fall back to project scope.
+   */
+  private findSkillPath(skillName: string): string | null {
+    // scope map is built by loadSkillRules; populate it once on demand so content lookup
+    // is not order-dependent on the caller having loaded rules first. Guard on the loaded
+    // flag, not map size — a zero-skill config would otherwise re-read both files every call
+    if (!this.scopesLoaded && this.userSkillsDir) {
+      this.loadSkillRules();
+    }
+
+    // reject traversal and path segments before touching the filesystem
+    if (
+      !skillName ||
+      skillName.includes("..") ||
+      skillName.includes("/") ||
+      skillName.includes("\\") ||
+      path.isAbsolute(skillName)
+    ) {
+      return null;
+    }
+
+    const scope = this.skillScopes.get(skillName);
+    const dir =
+      scope === "user" && this.userSkillsDir
+        ? this.userSkillsDir
+        : this.skillsDir;
+
+    // Accept both `SKILL.md` and `skill.md`. Skills are discovered with a case-insensitive
+    // glob, so on a case-sensitive filesystem a lowercase `skill.md` skill would sync and
+    // validate cleanly but its content would never load here — "scored but silently never
+    // surfaces", the exact failure the validation hardening exists to prevent.
+    for (const file of ["SKILL.md", "skill.md"]) {
+      const skillPath = path.join(dir, skillName, file);
+      if (fs.existsSync(skillPath)) return skillPath;
+    }
+    return null;
   }
 }
 

--- a/packages/claude-skill-runtime/src/hook-output.mts
+++ b/packages/claude-skill-runtime/src/hook-output.mts
@@ -285,7 +285,12 @@ export function buildPreToolUseDenyOutput(
 }
 
 /**
- * Build PreToolUse allow output
+ * Build PreToolUse allow output.
+ *
+ * WARNING: `permissionDecision: "allow"` actively GRANTS the tool call, bypassing the
+ * normal permission system. Use this only when the hook's intent is to authorize the
+ * tool — never merely to surface information. For advisory/warning output that must NOT
+ * change the permission outcome, use `buildPreToolUseContextOutput`.
  */
 export function buildPreToolUseAllowOutput(
   additionalContext?: string
@@ -298,6 +303,30 @@ export function buildPreToolUseAllowOutput(
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "allow",
+      additionalContext,
+    },
+  };
+}
+
+/**
+ * Build neutral PreToolUse output that adds context WITHOUT making a permission decision.
+ *
+ * An omitted `permissionDecision` means "do nothing" per the PreToolUse contract — the
+ * normal permission flow and any other hooks still apply. This is the correct shape for a
+ * non-blocking guardrail warning: it must inform, not authorize. (A prior version routed
+ * warnings through `buildPreToolUseAllowOutput`, which silently granted permission the
+ * moment a `warn` rule actually matched.)
+ */
+export function buildPreToolUseContextOutput(
+  additionalContext?: string
+): PreToolUseOutput {
+  if (!additionalContext) {
+    return {};
+  }
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
       additionalContext,
     },
   };

--- a/packages/claude-skill-runtime/src/hook-utils.mts
+++ b/packages/claude-skill-runtime/src/hook-utils.mts
@@ -24,10 +24,49 @@ export interface HookContext {
  * Options for initializing hook context
  */
 export interface InitHookContextOptions {
-  /** Working directory from hook input */
-  workingDirectory: string;
+  /**
+   * Working directory from hook input.
+   *
+   * Claude Code sends this as `cwd`; older payloads used `working_directory`.
+   * Prefer passing the raw payload field through `resolveHookDir()` so both shapes work.
+   */
+  workingDirectory?: string;
+  /** Current working directory from hook input (`cwd` in current Claude Code payloads) */
+  cwd?: string;
   /** Whether to initialize session state (default: true) */
   initSessionState?: boolean;
+  /**
+   * Also read user-level rules from ~/.claude/skills/ and merge them under project rules
+   * (project wins on skill-name collision). Default false — project-only, unchanged.
+   */
+  userScope?: boolean;
+}
+
+/**
+ * Raw hook payload fields that can carry the invocation directory.
+ *
+ * Claude Code currently sends `cwd`; earlier versions sent `working_directory`.
+ * Hook templates should not read either field directly.
+ */
+export interface HookDirInput {
+  cwd?: string;
+  working_directory?: string;
+}
+
+/**
+ * Resolve the directory a hook was invoked in, across payload shapes.
+ *
+ * Returns undefined when neither field is present, so callers can fall back
+ * (initHookContext falls back to CLAUDE_PROJECT_DIR, then process.cwd()).
+ *
+ * @example
+ * ```ts
+ * const data = JSON.parse(await readStdin()) as HookDirInput & { prompt: string };
+ * const ctx = initHookContext({ cwd: resolveHookDir(data) });
+ * ```
+ */
+export function resolveHookDir(data: HookDirInput | undefined): string | undefined {
+  return data?.cwd ?? data?.working_directory;
 }
 
 /**
@@ -67,7 +106,8 @@ export function readStdin(): Promise<string> {
  * Initialize standard hook context
  *
  * Consolidates the common initialization pattern used by all hooks:
- * - Determines project directory (from CLAUDE_PROJECT_DIR env or working_directory)
+ * - Determines project directory (CLAUDE_PROJECT_DIR env, then cwd, then working_directory,
+ *   then process.cwd() — so a payload missing every directory field still resolves)
  * - Initializes session state
  * - Loads configuration
  * - Creates logger
@@ -75,16 +115,22 @@ export function readStdin(): Promise<string> {
  * @example
  * ```ts
  * const { projectDir, configLoader, config, logger } = initHookContext({
- *   workingDirectory: data.working_directory,
+ *   cwd: resolveHookDir(data),
  * });
  * ```
  */
 export function initHookContext(options: InitHookContextOptions): HookContext {
-  const { workingDirectory, initSessionState: shouldInitSessionState = true } =
-    options;
+  const {
+    workingDirectory,
+    cwd,
+    initSessionState: shouldInitSessionState = true,
+    userScope = false,
+  } = options;
 
-  // determine project directory
-  const projectDir = process.env.CLAUDE_PROJECT_DIR ?? workingDirectory;
+  // determine project directory; process.cwd() is the last resort so a hook never
+  // throws on an unfamiliar payload shape
+  const projectDir =
+    process.env.CLAUDE_PROJECT_DIR ?? cwd ?? workingDirectory ?? process.cwd();
 
   // initialize session state if requested
   if (shouldInitSessionState) {
@@ -92,7 +138,7 @@ export function initHookContext(options: InitHookContextOptions): HookContext {
   }
 
   // load configuration
-  const configLoader = new ConfigLoader(projectDir);
+  const configLoader = new ConfigLoader(projectDir, { userScope });
   const config = configLoader.loadSkillRules();
 
   // create logger

--- a/packages/claude-skill-runtime/src/index.mts
+++ b/packages/claude-skill-runtime/src/index.mts
@@ -31,6 +31,7 @@ export type {
 
 // config loading
 export { ConfigLoader, getLogger, createDefaultConfig } from "./config-loader.mjs";
+export type { ConfigLoaderOptions } from "./config-loader.mjs";
 
 // rule matching
 export { RuleMatcher } from "./rule-matcher.mjs";
@@ -57,12 +58,14 @@ export type {
   HookContext,
   InitHookContextOptions,
   HandleHookErrorOptions,
+  HookDirInput,
 } from "./hook-utils.mjs";
 
 export {
   readStdin,
   initHookContext,
   handleHookError,
+  resolveHookDir,
 } from "./hook-utils.mjs";
 
 // pattern utilities (shared regex pattern handling)
@@ -102,6 +105,7 @@ export {
   buildBlockOutput,
   buildPreToolUseDenyOutput,
   buildPreToolUseAllowOutput,
+  buildPreToolUseContextOutput,
   buildPreToolUseAskOutput,
 } from "./hook-output.mjs";
 

--- a/packages/claude-skill-runtime/src/rule-matcher.mts
+++ b/packages/claude-skill-runtime/src/rule-matcher.mts
@@ -21,6 +21,42 @@ import type {
 import { resolveFilePath } from "./path-utils.mjs";
 
 /**
+ * Collect the string leaf values of a hook payload for regex matching.
+ *
+ * Tool inputs arrive as objects (`{ command: "rm -rf /", description: "…" }`). Patterns
+ * are tested against each string leaf SEPARATELY rather than against a JSON dump of the
+ * object, because a dump breaks anchored patterns — `^rm ` can never match a subject that
+ * starts with `{"command":` — and injects key names and JSON escaping into the subject.
+ *
+ * Cycles are guarded, and any traversal failure yields an empty list rather than throwing:
+ * a hook must never crash on odd input.
+ */
+function collectStrings(value: unknown, seen = new WeakSet<object>()): string[] {
+  if (typeof value === "string") return [value];
+  // deliberately NOT numbers/booleans: coercing them makes a pattern like `^false$`
+  // match an unrelated flag such as `{ sandbox: false }`. Patterns are written against
+  // user-authored text (commands, file paths, prompts), which is always a string.
+  if (value === null || value === undefined) return [];
+  if (typeof value !== "object") return [];
+
+  // value is an object/array from here on
+  if (seen.has(value)) return []; // cycle
+  seen.add(value);
+  try {
+    const children = Array.isArray(value)
+      ? value
+      : Object.values(value as Record<string, unknown>);
+    return children.flatMap((child) => collectStrings(child, seen));
+  } catch {
+    return [];
+  } finally {
+    // release on the way out so a repeated *sibling* reference is still visited —
+    // only genuine cycles (an ancestor revisited) are skipped
+    seen.delete(value);
+  }
+}
+
+/**
  * Match prompts and files against skill rules
  */
 export class RuleMatcher {
@@ -277,8 +313,22 @@ export class RuleMatcher {
    * Match tool usage against pre-tool triggers
    * Returns skills that should be loaded/suggested before tool execution
    */
-  matchPreToolTriggers(toolName: string, toolInput: string): PreToolMatch[] {
+  matchPreToolTriggers(toolName: string, toolInput: unknown): PreToolMatch[] {
     const matches: PreToolMatch[] = [];
+
+    // Claude Code sends tool_input as an OBJECT (e.g. { command: "rm -rf /" }). Passing it
+    // straight to RegExp.test coerced it to "[object Object]", so every inputPatterns rule
+    // silently failed to match and the guardrail never fired.
+    //
+    // Serialization is deferred and memoized: this runs on EVERY tool call, and a large
+    // Write/Edit payload should not be stringified in projects whose rules never inspect
+    // the input.
+    let inputTextsCache: string[] | null = null;
+    const inputTexts = (): string[] => {
+      inputTextsCache ??=
+        typeof toolInput === "string" ? [toolInput] : collectStrings(toolInput);
+      return inputTextsCache;
+    };
 
     if (!this.config.skills || typeof this.config.skills !== "object") {
       return matches;
@@ -315,7 +365,7 @@ export class RuleMatcher {
       const compiledPatterns =
         this.compiledPatterns.get(skillName)?.preToolInputPatterns ?? [];
       for (const pattern of compiledPatterns) {
-        if (pattern.test(toolInput)) {
+        if (inputTexts().some((text) => pattern.test(text))) {
           this.logger?.log("activation", "pre-tool match", {
             skill: skillName,
             toolName,

--- a/packages/create-auto-loading-claude-skills/src/bin/cli.ts
+++ b/packages/create-auto-loading-claude-skills/src/bin/cli.ts
@@ -100,6 +100,10 @@ program
   .command("validate")
   .description("Validate skill-rules configuration")
   .option("-f, --fix", "Auto-fix issues where possible")
+  // validateCommand has always read options.verbose and told users to "Run with
+  // --verbose", but the flag was never registered — passing it failed as unknown
+  .option("-v, --verbose", "Show a suggestion for each issue")
+  .option("-y, --yes", "Apply --fix repairs without prompting (for CI)")
   .action(async (options: ValidateOptions) => {
     const { validateCommand } = await import("../commands/validate.js");
     await validateCommand(options);

--- a/packages/create-auto-loading-claude-skills/src/commands/add-skill-wizard.ts
+++ b/packages/create-auto-loading-claude-skills/src/commands/add-skill-wizard.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import path from "path";
 
 import type { WizardOptions } from "../types/index.js";
+import { skillExists } from "../utils/skill-paths.js";
 import type { SkillConfig, SkillRule } from "@satoshibits/claude-skill-runtime";
 
 interface WizardAnswers {
@@ -46,15 +47,14 @@ export async function addSkillWizardCommand(
 ) {
   const cwd = process.cwd();
   const skillsDir = path.join(cwd, ".claude", "skills");
-  const skillDir = path.join(skillsDir, skillName);
 
   console.log(chalk.blue.bold("\n🧙 Skill Classification Wizard\n"));
   console.log(
     chalk.dim("This wizard helps determine the optimal loading strategy.\n"),
   );
 
-  // check if skill already exists
-  if (fs.existsSync(path.join(skillDir, "SKILL.md"))) {
+  // check if skill already exists (both SKILL.md / skill.md, via the shared predicate)
+  if (skillExists(skillsDir, skillName)) {
     console.log(chalk.yellow(`⚠️  Skill '${skillName}' already exists.`));
     const { proceed } = (await prompts({
       type: "confirm",

--- a/packages/create-auto-loading-claude-skills/src/commands/sync.ts
+++ b/packages/create-auto-loading-claude-skills/src/commands/sync.ts
@@ -35,6 +35,7 @@ import {
   parseFrontmatter,
   smartTriggersToSkillRule,
 } from "../parsers/frontmatter-parser.js";
+import { skillExists } from "../utils/skill-paths.js";
 
 /**
  * Extended SkillConfig with sync metadata for tracking auto-synced vs manual skills
@@ -88,10 +89,16 @@ interface SkillFile {
 }
 
 /**
- * Find all SKILL.md files in ~/.claude/skills/ (personal) and .claude/commands/ (project)
- * Project skills take precedence over personal skills with the same name
+ * Find all SKILL.md files in ~/.claude/skills/ (personal) and <root>/.claude/skills/
+ * (project). Project skills take precedence over personal skills with the same name.
+ *
+ * Pure discovery: no console output, so read-only callers (sync-status) stay silent.
+ * `legacyCommandsCount` reports SKILL.md files left under the deprecated `.claude/commands/`
+ * location so the caller can advise the user; nothing there is synced.
  */
-async function findSkillFiles(rootDir: string): Promise<SkillFile[]> {
+async function findSkillFiles(
+  rootDir: string,
+): Promise<{ files: SkillFile[]; legacyCommandsCount: number }> {
   const results: SkillFile[] = [];
 
   // 1. personal scope: ~/.claude/skills/
@@ -107,31 +114,50 @@ async function findSkillFiles(rootDir: string): Promise<SkillFile[]> {
     }
   }
 
-  // 2. project scope: .claude/commands/ (takes precedence)
-  const commandsDir = path.join(rootDir, ".claude", "commands");
-  if (fs.existsSync(commandsDir)) {
-    const projectPatterns = [
-      path.join(commandsDir, "**/SKILL.md"),
-      path.join(commandsDir, "**/skill.md"),
-    ];
-    for (const pattern of projectPatterns) {
+  // 2. project scope (takes precedence). `.claude/skills/` ONLY — it is what `init`
+  // creates, what `validate` checks, and what the runtime's ConfigLoader reads. The
+  // deprecated `.claude/commands/` is NOT synced: no reader resolves content there, so a
+  // rule generated from it always reported as orphaned and never loaded. Files left there
+  // are counted and surfaced by the caller, not silently synced.
+  const projectSkillsDir = path.join(rootDir, ".claude", "skills");
+  if (fs.existsSync(projectSkillsDir)) {
+    for (const pattern of [
+      path.join(projectSkillsDir, "**/SKILL.md"),
+      path.join(projectSkillsDir, "**/skill.md"),
+    ]) {
       const matches = await glob(pattern, { nocase: true });
       results.push(...matches.map((p) => ({ path: p, scope: "project" as const })));
     }
   }
 
+  const legacyCommandsDir = path.join(rootDir, ".claude", "commands");
+  const legacyCommandsCount = fs.existsSync(legacyCommandsDir)
+    ? (await glob(path.join(legacyCommandsDir, "**/SKILL.md"), { nocase: true })).length
+    : 0;
+
   // dedupe by path and sort
   const seen = new Set<string>();
-  return results.filter((f) => {
-    if (seen.has(f.path)) return false;
-    seen.add(f.path);
-    return true;
-  }).sort((a, b) => a.path.localeCompare(b.path));
+  const files = results
+    .filter((f) => {
+      if (seen.has(f.path)) return false;
+      seen.add(f.path);
+      return true;
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  return { files, legacyCommandsCount };
 }
 
-/**
- * Load existing skill-rules.yaml
- */
+/** Advise about SKILL.md files left under the deprecated `.claude/commands/` location. */
+function reportLegacyCommands(count: number): void {
+  console.log(
+    chalk.yellow(
+      `\n⚠️  ${count} SKILL.md file(s) found under .claude/commands/ — not synced.\n` +
+        `   Move them to .claude/skills/<name>/SKILL.md to be resolvable.\n`,
+    ),
+  );
+}
+
 function loadExistingConfig(configPath: string): SkillRulesConfig | null {
   if (!fs.existsSync(configPath)) {
     return null;
@@ -157,16 +183,43 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
   const skillsDir = path.join(cwd, ".claude", "skills");
   const configPath = path.join(skillsDir, "skill-rules.yaml");
 
+  // Writing personal (~/.claude) skills into a PROJECT config breaks them: the runtime
+  // resolves a skill's SKILL.md only from the scope that declared it, so a
+  // project-declared copy of a personal skill points at <project>/.claude/skills/<name>,
+  // which does not exist — and, because project wins collisions, it also shadows the
+  // working user-scope entry. That scope isolation is deliberate: a project config is
+  // untrusted data, so it must not be able to name a file under $HOME. When syncing a
+  // project, emit project skills only.
+  const userSkillsDir = path.join(os.homedir(), ".claude", "skills");
+  const syncingUserScope =
+    path.resolve(skillsDir) === path.resolve(userSkillsDir);
+  /** personal skills deliberately not written into a project config (see above) */
+  const skippedPersonal: string[] = [];
+
   // 1. find skill files from both personal and project scopes
   const spinner = ora("Scanning for SKILL.md files...").start();
-  const skillFiles = await findSkillFiles(cwd);
+  const { files: skillFiles, legacyCommandsCount } = await findSkillFiles(cwd);
 
   if (skillFiles.length === 0) {
-    spinner.warn("No SKILL.md files found in ~/.claude/skills/ or .claude/commands/");
-    console.log(
-      chalk.dim("Create skills using: cl-auto-skills add-skill <name>"),
+    spinner.warn(
+      "No SKILL.md files found in ~/.claude/skills/ or <project>/.claude/skills/",
     );
-    return;
+
+    // If a synced config already exists, keep going with an empty rule set so the stale
+    // entries are cleared. Returning here left `sync-status` permanently stale after the
+    // last SKILL.md was deleted, with `sync` refusing to repair it.
+    const priorConfig = loadExistingConfig(configPath);
+    if (!priorConfig?._sync) {
+      if (legacyCommandsCount > 0) reportLegacyCommands(legacyCommandsCount);
+      console.log(
+        chalk.dim("Create skills using: cl-auto-skills add-skill <name>"),
+      );
+      return;
+    }
+
+    console.log(
+      chalk.dim("Clearing previously synced entries from skill-rules.yaml"),
+    );
   }
 
   const personalCount = skillFiles.filter((f) => f.scope === "personal").length;
@@ -176,11 +229,12 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
       (personalCount > 0 ? chalk.dim(` (${personalCount} personal, ${projectCount} project)`) : ""),
   );
 
+  if (legacyCommandsCount > 0) reportLegacyCommands(legacyCommandsCount);
+
   // 2. load existing config
   const existingConfig = loadExistingConfig(configPath);
   const existingSkills = existingConfig?.skills ?? {};
   const syncMetadata = existingConfig?._sync;
-  const _previousSyncedSkills = new Set(syncMetadata?.syncedSkills ?? []);
   const manualSkills = new Set(syncMetadata?.manualSkills ?? []);
 
   // 3. parse each skill file
@@ -257,6 +311,18 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
       if (idx !== -1) result.synced.splice(idx, 1);
     }
 
+    if (scope === "personal" && !syncingUserScope) {
+      // belongs in ~/.claude/skills/skill-rules.yaml, not in this project's config.
+      // tracked separately so the summary does not claim the frontmatter is missing
+      skippedPersonal.push(skillName);
+      if (verbose) {
+        console.log(
+          chalk.dim(`    Skipped (personal scope — sync from your home dir instead)`),
+        );
+      }
+      continue;
+    }
+
     syncedRules[skillName] = rule;
     skillScopes[skillName] = scope;
     result.synced.push(skillName);
@@ -273,6 +339,16 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
   // 4. merge with existing config
   const mergedSkills: Record<string, SkillRule> = {};
   const newManualSkills: string[] = [];
+  /** previously-synced personal entries removed from a project config (migration) */
+  const droppedPersonal: string[] = [];
+  /** previously-synced entries whose SKILL.md no longer exists */
+  const droppedStale: string[] = [];
+  /**
+   * Previously-synced entries whose SKILL.md is still present but produced no rule this
+   * run (parse error / triggers removed). Preserved AND kept sync-owned, so a later
+   * genuine deletion still triggers the stale-drop instead of the rule lingering forever.
+   */
+  const preservedSyncOwned: string[] = [];
 
   // first, add all synced skills
   for (const [name, rule] of Object.entries(syncedRules)) {
@@ -288,8 +364,34 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
         mergedSkills[name] = { ...mergedSkills[name], ...rule };
         result.preserved.push(name);
       }
+    } else if (
+      !syncingUserScope &&
+      syncMetadata?.skillScopes?.[name] === "personal"
+    ) {
+      // MIGRATION: a previous release copied personal skills into this project config.
+      // Their SKILL.md lives under $HOME, never under the project, so the runtime cannot
+      // resolve them and — because project rules win collisions — they shadow the working
+      // user-scope skill. Always drop them from a project config.
+      droppedPersonal.push(name);
+    } else if (
+      syncMetadata?.skillScopes?.[name] &&
+      !skillExists(skillsDir, name)
+    ) {
+      // Previously synced, and its SKILL.md is genuinely GONE (not merely unparseable or
+      // stripped of triggers — those still exist on disk). Drop it so a deleted skill's
+      // generated rule doesn't linger forever. Same existence predicate `validate` uses.
+      droppedStale.push(name);
+    } else if (syncMetadata?.skillScopes?.[name]) {
+      // Previously synced, file still present but produced no rule this run (parse error /
+      // triggers removed). Preserve the rule, but keep it SYNC-OWNED — carrying its prior
+      // scope forward (below) — so a later genuine deletion still drops it. Demoting it to
+      // "manual" here would permanently defeat the stale-drop for that skill.
+      mergedSkills[name] = rule;
+      preservedSyncOwned.push(name);
+      skillScopes[name] = syncMetadata.skillScopes[name];
+      result.preserved.push(name);
     } else {
-      // skill not in SKILL.md files, preserve it as manual
+      // Genuinely hand-written (no sync metadata): preserve as a manual entry.
       mergedSkills[name] = rule;
       newManualSkills.push(name);
       result.preserved.push(name);
@@ -310,7 +412,9 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     _sync: {
       lastSync: new Date().toISOString(),
       checksum,
-      syncedSkills: Object.keys(syncedRules),
+      // keep transiently-broken synced skills in the sync-owned set so their scope
+      // metadata survives and a later deletion still drops them
+      syncedSkills: [...Object.keys(syncedRules), ...preservedSyncOwned],
       manualSkills: newManualSkills,
       skillScopes,
     },
@@ -334,6 +438,43 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     );
     if (verbose) {
       result.skipped.forEach((s) => console.log(chalk.dim(`    ${s}`)));
+    }
+  }
+
+  if (droppedStale.length > 0) {
+    console.log(
+      chalk.yellow(
+        `⊘ ${dryRun ? "Would remove" : "Removed"} ${droppedStale.length} stale ` +
+          `entr(y/ies) — their SKILL.md no longer exists`,
+      ),
+    );
+    if (verbose) {
+      droppedStale.forEach((s) => console.log(chalk.dim(`    ${s}`)));
+    }
+  }
+
+  if (droppedPersonal.length > 0) {
+    console.log(
+      chalk.yellow(
+        `⊘ ${dryRun ? "Would remove" : "Removed"} ${droppedPersonal.length} personal ` +
+          `skill(s) previously copied into this project's config — they live in ` +
+          `~/.claude/skills and are resolved from there`,
+      ),
+    );
+    if (verbose) {
+      droppedPersonal.forEach((s) => console.log(chalk.dim(`    ${s}`)));
+    }
+  }
+
+  if (skippedPersonal.length > 0) {
+    console.log(
+      chalk.yellow(
+        `⊘ Skipped: ${skippedPersonal.length} personal skill(s) — run sync from your ` +
+          `home directory to write ~/.claude/skills/skill-rules.yaml`,
+      ),
+    );
+    if (verbose) {
+      skippedPersonal.forEach((s) => console.log(chalk.dim(`    ${s}`)));
     }
   }
 
@@ -449,13 +590,20 @@ export async function checkSyncStatus(
     };
   }
 
-  // find current skill files and compute checksum
-  const skillFiles = await findSkillFiles(rootDir);
+  // find current skill files and compute checksum (read-only: no legacy notice here)
+  const { files: skillFiles } = await findSkillFiles(rootDir);
   const currentRules: Record<string, Partial<SkillRule>> = {};
   const skillScopes: Record<string, "personal" | "project"> = {};
 
+  // must mirror syncCommand's scope rule exactly — including personal skills here while
+  // sync excludes them would report "stale" the instant after a clean sync
+  const statusUserSkillsDir = path.join(os.homedir(), ".claude", "skills");
+  const statusSyncingUserScope =
+    path.resolve(skillsDir) === path.resolve(statusUserSkillsDir);
+
   for (const skillFile of skillFiles) {
     const { path: filePath, scope } = skillFile;
+    if (scope === "personal" && !statusSyncingUserScope) continue;
     const content = fs.readFileSync(filePath, "utf8");
     const parsed = parseFrontmatter(content, filePath);
 

--- a/packages/create-auto-loading-claude-skills/src/commands/validate.ts
+++ b/packages/create-auto-loading-claude-skills/src/commands/validate.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import path from "path";
 
 import type { ValidateOptions } from "../types/index.js";
+import { skillExists } from "../utils/skill-paths.js";
 import type { SkillConfig, SkillRule } from "@satoshibits/claude-skill-runtime";
 
 interface ValidationIssue {
@@ -31,6 +32,16 @@ export async function validateCommand(options: ValidateOptions) {
   // 2. Load skill-rules configuration
   const config = loadSkillRules(skillsDir);
 
+  if (config && (typeof config !== "object" || Array.isArray(config))) {
+    console.log(
+      chalk.red("❌ Error: skill-rules must be a mapping at the top level"),
+    );
+    console.log(
+      chalk.dim(`   Parsed as ${Array.isArray(config) ? "an array" : typeof config}\n`),
+    );
+    process.exit(1);
+  }
+
   if (!config) {
     console.log(chalk.red("❌ Error: No skill-rules configuration found"));
     console.log(
@@ -42,11 +53,61 @@ export async function validateCommand(options: ValidateOptions) {
   // 3. Collect all validation issues
   const issues: ValidationIssue[] = [];
 
+  // The `skills:` block has three distinct states. A present-but-malformed block (scalar
+  // or list) must be reported as an ERROR and never rewritten — `config` is the object
+  // autoFixIssues serializes to disk, so coercing `config.skills = {}` here would silently
+  // destroy the user's data. An ABSENT block is safely normalized to an empty mapping.
+  const skillsAbsent = config.skills === undefined || config.skills === null;
+  const skillsBlockValid =
+    !skillsAbsent &&
+    typeof config.skills === "object" &&
+    !Array.isArray(config.skills);
+  /** present, but not a mapping — rewriting the file would discard the user's data */
+  const skillsBlockMalformed = !skillsAbsent && !skillsBlockValid;
+
+  if (skillsBlockMalformed) {
+    issues.push({
+      severity: "error",
+      skillName: "(root)",
+      message: `\`skills:\` must be a mapping — parsed as ${
+        Array.isArray(config.skills) ? "a list" : typeof config.skills
+      }`,
+      suggestion: "Use `skills:` with one nested entry per skill name",
+    });
+  }
+
+  if (skillsAbsent) {
+    // absent is not malformed: normalizing to an empty mapping discards nothing and lets
+    // auto-fix register discovered skills
+    config.skills = {};
+  }
+
+  const skills: Record<string, unknown> = skillsBlockMalformed
+    ? {}
+    : (config.skills as unknown as Record<string, unknown>);
+
+  // Malformed rules are RECORDED, not deleted: `config` is the same object autoFixIssues
+  // serializes back to disk, so deleting here silently dropped the user's rule while the
+  // output told them to fix it manually.
+  const malformedRules = new Set<string>();
+  for (const [skillName, rule] of Object.entries(skills)) {
+    if (!rule || typeof rule !== "object" || Array.isArray(rule)) {
+      malformedRules.add(skillName);
+      issues.push({
+        severity: "error",
+        skillName,
+        message: "Rule is empty — expected a mapping of settings",
+        suggestion: "Give the skill at least type, enforcement, priority and description",
+      });
+    }
+  }
+
   // 3a. Check for orphaned skills (in yaml but no SKILL.md)
   const orphanedSkills: string[] = [];
   const validSkills: string[] = [];
 
-  for (const skillName of Object.keys(config.skills)) {
+  for (const skillName of Object.keys(skills)) {
+    if (malformedRules.has(skillName)) continue; // already reported above
     if (skillExists(skillsDir, skillName)) {
       validSkills.push(skillName);
     } else {
@@ -70,7 +131,7 @@ export async function validateCommand(options: ValidateOptions) {
       .map((d) => d.name);
 
     for (const dir of dirs) {
-      if (!config.skills[dir] && skillExists(skillsDir, dir)) {
+      if (!skills[dir] && skillExists(skillsDir, dir)) {
         unregisteredSkills.push(dir);
         issues.push({
           severity: "warning",
@@ -83,8 +144,9 @@ export async function validateCommand(options: ValidateOptions) {
   }
 
   // 3c. Validate trigger configurations
-  for (const [skillName, rule] of Object.entries(config.skills)) {
-    const triggerIssues = validateTriggers(skillName, rule);
+  for (const [skillName, rule] of Object.entries(skills)) {
+    if (malformedRules.has(skillName)) continue; // no shape to validate
+    const triggerIssues = validateTriggers(skillName, rule as SkillRule);
     issues.push(...triggerIssues);
   }
 
@@ -144,8 +206,42 @@ export async function validateCommand(options: ValidateOptions) {
   }
 
   // 5. Auto-fix if requested
-  if (options.fix) {
-    await autoFixIssues(config, orphanedSkills, unregisteredSkills, skillsDir);
+  if (options.fix && skillsBlockMalformed) {
+    console.log(
+      chalk.red(
+        "\n❌ Refusing to auto-fix: the `skills:` block is not a mapping, and rewriting\n" +
+          "   the file would discard it. Fix the block by hand first.\n",
+      ),
+    );
+    process.exitCode = 1;
+  } else if (options.fix) {
+    // Exit status is derived from what auto-fix ACTUALLY removed. The prompts are
+    // interactive: with stdin closed (any CI runner) they abort and nothing is repaired,
+    // so assuming the orphaned rules were deleted would exit 0 over an untouched config.
+    const { removedSkills, addedSkills } = await autoFixIssues(
+      config,
+      orphanedSkills,
+      unregisteredSkills,
+      skillsDir,
+      options.yes === true,
+    );
+    // Count an error as resolved only if auto-fix ACTUALLY removed the rule or registered
+    // the skill — a declined prompt or non-TTY early return leaves both sets empty, so
+    // nothing is falsely counted. `removedSkills` is the load-bearing term today (added
+    // skills are unregistered → warnings, never errors); `addedSkills` is included for
+    // correctness so this stays right if an error is ever attached to an added name.
+    const repaired = new Set([...removedSkills, ...addedSkills]);
+    const remainingErrors = errors.filter(
+      (issue) => !repaired.has(issue.skillName),
+    );
+    if (remainingErrors.length > 0) {
+      console.log(
+        chalk.red(
+          `\n❌ ${remainingErrors.length} error(s) remain after auto-fix — edit skill-rules manually.\n`,
+        ),
+      );
+      process.exitCode = 1;
+    }
   } else {
     console.log(
       chalk.dim(
@@ -157,6 +253,12 @@ export async function validateCommand(options: ValidateOptions) {
         `Run with ${chalk.cyan("--verbose")} for detailed suggestions\n`,
       ),
     );
+
+    // errors must fail the process so `validate` can gate a commit or CI job;
+    // warnings stay non-fatal. Auto-fix runs report their own outcome instead.
+    if (errors.length > 0) {
+      process.exitCode = 1;
+    }
   }
 }
 
@@ -198,13 +300,6 @@ function loadSkillRules(skillsDir: string): SkillConfig | null {
   return null;
 }
 
-/**
- * Check if skill exists (SKILL.md file)
- */
-function skillExists(skillsDir: string, skillName: string): boolean {
-  const skillPath = path.join(skillsDir, skillName, "SKILL.md");
-  return fs.existsSync(skillPath);
-}
 
 /**
  * Validate trigger configurations for a skill
@@ -217,23 +312,20 @@ function validateTriggers(
 
   // check for empty triggers on auto-load skills
   if (rule.enforcement !== "manual") {
+    // NOTE: these are boolean ORs, not `??`. They previously used `??`, which does not
+    // evaluate its right side when the left is `false` — so `keywords: []` combined with
+    // real `intentPatterns` was wrongly reported as having no triggers. Operands are
+    // reduced to strict booleans so the intent is unambiguous.
     const hasPromptTriggers =
-      rule.promptTriggers &&
-      ((rule.promptTriggers.keywords &&
-        rule.promptTriggers.keywords.length > 0) ??
-        (rule.promptTriggers.intentPatterns &&
-          rule.promptTriggers.intentPatterns.length > 0));
+      (rule.promptTriggers?.keywords?.length ?? 0) > 0 ||
+      (rule.promptTriggers?.intentPatterns?.length ?? 0) > 0;
     const hasFileTriggers =
-      rule.fileTriggers &&
-      ((rule.fileTriggers.pathPatterns &&
-        rule.fileTriggers.pathPatterns.length > 0) ??
-        (rule.fileTriggers.contentPatterns &&
-          rule.fileTriggers.contentPatterns.length > 0));
-    const hasPreToolTriggers = rule.preToolTriggers?.toolName;
+      (rule.fileTriggers?.pathPatterns?.length ?? 0) > 0 ||
+      (rule.fileTriggers?.contentPatterns?.length ?? 0) > 0;
+    const hasPreToolTriggers = Boolean(rule.preToolTriggers?.toolName);
     const hasStopTriggers =
-      rule.stopTriggers &&
-      ((rule.stopTriggers.keywords && rule.stopTriggers.keywords.length > 0) ??
-        rule.stopTriggers.promptEvaluation);
+      (rule.stopTriggers?.keywords?.length ?? 0) > 0 ||
+      Boolean(rule.stopTriggers?.promptEvaluation);
 
     if (
       !hasPromptTriggers &&
@@ -363,6 +455,85 @@ function validateTriggers(
     });
   }
 
+  // activationStrategy has an enum in the schema but was never checked here. An
+  // unrecognized value (e.g. "imperative") falls through the hook's switch to the
+  // native_only branch, so the skill silently never surfaces — the exact failure this
+  // engine exists to prevent.
+  const validStrategies = [
+    "guaranteed",
+    "suggestive",
+    "prompt_enhanced",
+    "native_only",
+  ];
+  if (
+    rule.activationStrategy &&
+    !validStrategies.includes(rule.activationStrategy)
+  ) {
+    issues.push({
+      severity: "error",
+      skillName,
+      message: `Invalid activationStrategy: ${rule.activationStrategy}`,
+      suggestion: `Use one of: ${validStrategies.join(", ")} — unrecognized values are treated as native_only and never fire`,
+    });
+  }
+
+  // required fields — schema/skill-rules.schema.json marks these required, but nothing
+  // executed the schema, so a rule missing them used to validate clean and then silently
+  // fail to display at runtime (the matcher scores it, the renderer drops it).
+  // Deliberately hand-rolled rather than pulling in ajv: this keeps the CLI dependency-free
+  // and the messages actionable. The JSON schema stays the authority for editor autocomplete.
+  const requiredFields: (keyof SkillRule)[] = [
+    "type",
+    "enforcement",
+    "priority",
+    "description",
+  ];
+  for (const field of requiredFields) {
+    const value = rule[field];
+    if (value === undefined || value === null || value === "") {
+      issues.push({
+        severity: "error",
+        skillName,
+        message: `Missing required field: ${field}`,
+        suggestion:
+          field === "description"
+            ? "Add a one-line description of when the skill applies"
+            : `Add ${field} (see schema/skill-rules.schema.json for allowed values)`,
+      });
+    }
+  }
+
+  // unknown keys — usually a casing mistake (activation_strategy vs activationStrategy,
+  // prompt_triggers vs promptTriggers). The schema is additionalProperties:false, so these
+  // are silently ignored at runtime and the skill never fires.
+  const knownKeys = new Set([
+    "activationStrategy",
+    "cooldownMinutes",
+    "description",
+    "enforcement",
+    "fileTriggers",
+    "preToolTriggers",
+    "priority",
+    "promptHook",
+    "promptTriggers",
+    "shadowTriggers",
+    "stopTriggers",
+    "type",
+    "validationRules",
+  ]);
+  for (const key of Object.keys(rule)) {
+    if (knownKeys.has(key)) continue;
+    const camel = key.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+    issues.push({
+      severity: "warning",
+      skillName,
+      message: `Unknown field: ${key} (ignored at runtime)`,
+      suggestion: knownKeys.has(camel)
+        ? `Did you mean "${camel}"?`
+        : `Remove it, or check schema/skill-rules.schema.json for valid fields`,
+    });
+  }
+
   return issues;
 }
 
@@ -374,24 +545,54 @@ async function autoFixIssues(
   orphanedSkills: string[],
   unregisteredSkills: string[],
   skillsDir: string,
-) {
+  assumeYes = false,
+): Promise<{
+  removedSkills: Set<string>;
+  addedSkills: Set<string>;
+  modified: boolean;
+}> {
   console.log(chalk.bold("🔧 Auto-fix mode:\n"));
 
   let modified = false;
+  const removedSkills = new Set<string>();
+  const addedSkills = new Set<string>();
+
+  // Every repair is gated behind an interactive confirm. With stdin closed — any CI
+  // runner — `prompts` aborts and terminates the process from inside the prompt, so
+  // nothing is repaired AND no later code runs. Detect that up front instead.
+  if (!assumeYes && !process.stdin.isTTY) {
+    console.log(
+      chalk.yellow(
+        "⚠️  --fix requires an interactive terminal (stdin is not a TTY).\n" +
+          "   Re-run interactively, pass --yes to apply repairs unattended, or edit\n" +
+          "   skill-rules manually. Nothing was changed.\n",
+      ),
+    );
+    return { removedSkills, addedSkills, modified };
+  }
+
+  /** With --yes, repairs apply unattended; otherwise each is confirmed interactively. */
+  const confirm = async (message: string): Promise<boolean> => {
+    if (assumeYes) return true;
+    const { ok } = (await prompts({
+      type: "confirm",
+      name: "ok",
+      message,
+      initial: true,
+    })) as { ok?: boolean };
+    return ok === true;
+  };
 
   // Remove orphaned references
   if (orphanedSkills.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { confirmRemove } = await prompts({
-      type: "confirm",
-      name: "confirmRemove",
-      message: `Remove ${orphanedSkills.length} orphaned skill reference(s) from skill-rules?`,
-      initial: true,
-    });
+    const confirmRemove = await confirm(
+      `Remove ${orphanedSkills.length} orphaned skill reference(s) from skill-rules?`,
+    );
 
     if (confirmRemove) {
       orphanedSkills.forEach((skillName) => {
         delete config.skills[skillName];
+        removedSkills.add(skillName);
         console.log(chalk.green(`  ✓ Removed: ${skillName}`));
       });
       modified = true;
@@ -400,13 +601,9 @@ async function autoFixIssues(
 
   // Add unregistered skills
   if (unregisteredSkills.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { confirmAdd } = await prompts({
-      type: "confirm",
-      name: "confirmAdd",
-      message: `Add ${unregisteredSkills.length} unregistered skill(s) to skill-rules?`,
-      initial: true,
-    });
+    const confirmAdd = await confirm(
+      `Add ${unregisteredSkills.length} unregistered skill(s) to skill-rules?`,
+    );
 
     if (confirmAdd) {
       for (const skillName of unregisteredSkills) {
@@ -424,6 +621,7 @@ async function autoFixIssues(
           },
           validationRules: [],
         };
+        addedSkills.add(skillName);
         console.log(chalk.green(`  ✓ Added: ${skillName}`));
       }
       modified = true;
@@ -459,4 +657,6 @@ async function autoFixIssues(
   } else {
     console.log(chalk.dim("\nNo changes made.\n"));
   }
+
+  return { removedSkills, addedSkills, modified };
 }

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/post-tool-use-tracker.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/post-tool-use-tracker.ts
@@ -4,6 +4,7 @@ import {
   initHookContext,
   normalizeFilePath,
   readStdin,
+  resolveHookDir,
   sessionState,
 } from "@satoshibits/claude-skill-runtime";
 
@@ -16,6 +17,8 @@ interface ToolInput {
     edits?: { file_path: string }[];
   };
   session_id: string;
+  cwd?: string;
+  working_directory?: string;
 }
 
 /**
@@ -30,9 +33,10 @@ async function main() {
 
     const { tool_name, tool_input, session_id } = data;
 
-    // initialize hook context
+    // initialize hook context (payload dir when present, else process.cwd())
     const { projectDir, logger: contextLogger } = initHookContext({
-      workingDirectory: process.cwd(),
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
 

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/pre-tool-use-validator-json.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/pre-tool-use-validator-json.ts
@@ -16,11 +16,12 @@
  * - Ask: { hookSpecificOutput: { permissionDecision: "ask", permissionDecisionReason: "..." } }
  */
 import {
-  buildPreToolUseAllowOutput,
+  buildPreToolUseContextOutput,
   buildPreToolUseDenyOutput,
   handleHookError,
   initHookContext,
   readStdin,
+  resolveHookDir,
   RuleMatcher,
 } from "@satoshibits/claude-skill-runtime";
 
@@ -32,9 +33,11 @@ import type {
 
 interface PreToolUseHookInput {
   session_id: string;
-  working_directory: string;
+  cwd?: string;
+  working_directory?: string;
   tool_name: string;
-  tool_input: string;
+  /** Claude Code sends an object (e.g. { command: "…" }); older payloads sent a string. */
+  tool_input: unknown;
 }
 
 /**
@@ -56,13 +59,18 @@ function buildDenyOutputForMatch(
 }
 
 /**
- * Build allow output with warnings (for "warn" enforcement)
+ * Build advisory output for "warn" enforcement.
+ *
+ * A warning must INFORM without changing the permission outcome, so this emits
+ * additionalContext with NO permissionDecision. It must never return `"allow"`: that
+ * would grant the tool call, and a `warn`-severity guardrail silently authorizing a tool
+ * (now that `inputPatterns` actually match object `tool_input`) is worse than not firing.
  */
-function buildAllowOutputWithWarnings(
+function buildWarningOutput(
   warnings: { skill: string; description: string; pattern?: string }[],
 ): PreToolUseOutput {
   if (warnings.length === 0) {
-    // no warnings - return empty (allows tool to proceed)
+    // no warnings - neutral, tool proceeds through the normal permission flow
     return {};
   }
 
@@ -73,7 +81,7 @@ function buildAllowOutputWithWarnings(
   );
   const additionalContext = `=== GUARDRAIL WARNINGS ===\nThe following guardrails matched but are not blocking:\n${warningLines.join("\n")}`;
 
-  return buildPreToolUseAllowOutput(additionalContext);
+  return buildPreToolUseContextOutput(additionalContext);
 }
 
 /**
@@ -86,7 +94,7 @@ async function main() {
     const input = await readStdin();
     const data: PreToolUseHookInput = JSON.parse(input) as PreToolUseHookInput;
 
-    const { session_id, working_directory, tool_name, tool_input } = data;
+    const { session_id, tool_name, tool_input } = data;
 
     // initialize hook context
     const {
@@ -95,14 +103,17 @@ async function main() {
       config,
       logger: contextLogger,
     } = initHookContext({
-      workingDirectory: working_directory,
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
 
     logger.log("activation", "PreToolUse JSON hook started (v2.1 corrected)", {
       sessionId: session_id,
       toolName: tool_name,
-      inputLength: tool_input.length,
+      // cheap shape info only — serializing the payload here would cost a full
+      // stringify of every Write/Edit on every tool call, for a debug-only field
+      inputType: typeof tool_input,
     });
 
     // match pre-tool triggers
@@ -150,12 +161,12 @@ async function main() {
     }));
 
     if (warnings.length > 0) {
-      logger.log("activation", "allowing with warnings", {
+      logger.log("activation", "surfacing warnings (no permission change)", {
         warningCount: warnings.length,
       });
     }
 
-    const output = buildAllowOutputWithWarnings(warnings);
+    const output = buildWarningOutput(warnings);
     console.log(JSON.stringify(output, null, 2));
     process.exit(0);
   } catch (error) {

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/pre-tool-use-validator.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/pre-tool-use-validator.ts
@@ -4,6 +4,7 @@ import {
   handleHookError,
   initHookContext,
   readStdin,
+  resolveHookDir,
   RuleMatcher,
 } from "@satoshibits/claude-skill-runtime";
 
@@ -14,9 +15,11 @@ import type {
 
 interface PreToolUseHookInput {
   session_id: string;
-  working_directory: string;
+  cwd?: string;
+  working_directory?: string;
   tool_name: string;
-  tool_input: string;
+  /** Claude Code sends an object (e.g. { command: "…" }); older payloads sent a string. */
+  tool_input: unknown;
 }
 
 /**
@@ -30,7 +33,7 @@ async function main() {
     const input = await readStdin();
     const data: PreToolUseHookInput = JSON.parse(input) as PreToolUseHookInput;
 
-    const { session_id, working_directory, tool_name, tool_input } = data;
+    const { session_id, tool_name, tool_input } = data;
 
     // initialize hook context
     const {
@@ -39,14 +42,17 @@ async function main() {
       config,
       logger: contextLogger,
     } = initHookContext({
-      workingDirectory: working_directory,
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
 
     logger.log("activation", "hook started", {
       sessionId: session_id,
       toolName: tool_name,
-      inputLength: tool_input.length,
+      // cheap shape info only — serializing the payload here would cost a full
+      // stringify of every Write/Edit on every tool call, for a debug-only field
+      inputType: typeof tool_input,
     });
 
     // match pre-tool triggers
@@ -96,11 +102,11 @@ function outputPreToolSuggestions(
   // handle blocking guardrails
   if (blocking.length > 0) {
     console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    console.log("🛑 TOOL EXECUTION BLOCKED");
+    console.log("⚠️  GUARDRAIL TRIGGERED (advisory — the tool still runs)");
     console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
 
     for (const match of blocking) {
-      console.log(`❌ ${match.skillName} GUARDRAIL TRIGGERED`);
+      console.log(`❌ ${match.skillName} requirements not met`);
       console.log(`   ${match.rule.description}`);
       console.log(`   Tool: ${match.toolName}`);
       if (match.matchedPattern) {
@@ -126,10 +132,11 @@ function outputPreToolSuggestions(
     console.log(
       "⚠️  Please address the above requirements before proceeding.\n",
     );
+    console.log(
+      "   This hook is advisory: it prints and exits 0, so the tool is NOT blocked.\n" +
+        "   Use skill-activation-json / pre-tool-use-validator-json for a real deny.\n",
+    );
     console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
-
-    // exit with error to potentially block the tool (depending on hook config)
-    // process.exit(1); // uncomment to actually block
   }
 
   // handle warnings

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/session-start.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/session-start.ts
@@ -14,6 +14,7 @@ import {
   handleHookError,
   initHookContext,
   readStdin,
+  resolveHookDir,
   sessionState,
 } from "@satoshibits/claude-skill-runtime";
 import { execSync } from "child_process";
@@ -27,7 +28,8 @@ import type {
 
 interface HookInput {
   session_id: string;
-  working_directory: string;
+  cwd?: string;
+  working_directory?: string;
 }
 
 interface FileState {
@@ -157,7 +159,7 @@ async function main() {
     const input = await readStdin();
     const data: HookInput = JSON.parse(input) as HookInput;
 
-    const { session_id, working_directory } = data;
+    const { session_id } = data;
 
     // initialize hook context
     const {
@@ -165,7 +167,8 @@ async function main() {
       config,
       logger: contextLogger,
     } = initHookContext({
-      workingDirectory: working_directory,
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
     const cacheDir = path.join(projectDir, ".claude", "cache");

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/skill-activation-json.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/skill-activation-json.ts
@@ -21,6 +21,7 @@ import {
   handleHookError,
   initHookContext,
   readStdin,
+  resolveHookDir,
   RuleMatcher,
   sessionState,
 } from "@satoshibits/claude-skill-runtime";
@@ -37,7 +38,8 @@ import type {
 interface HookInput {
   prompt: string;
   session_id: string;
-  working_directory: string;
+  cwd?: string;
+  working_directory?: string;
 }
 
 /**
@@ -168,7 +170,7 @@ async function main() {
     const input = await readStdin();
     const data: HookInput = JSON.parse(input) as HookInput;
 
-    const { prompt, session_id, working_directory } = data;
+    const { prompt, session_id } = data;
 
     // initialize hook context
     const {
@@ -177,7 +179,8 @@ async function main() {
       config,
       logger: contextLogger,
     } = initHookContext({
-      workingDirectory: working_directory,
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
     sessionState.clearCurrentPromptSkills(session_id);

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/skill-activation-prompt.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/skill-activation-prompt.ts
@@ -4,6 +4,7 @@ import {
   handleHookError,
   initHookContext,
   readStdin,
+  resolveHookDir,
   RuleMatcher,
   sessionState,
 } from "@satoshibits/claude-skill-runtime";
@@ -17,7 +18,8 @@ import type {
 interface HookInput {
   prompt: string;
   session_id: string;
-  working_directory: string;
+  cwd?: string;
+  working_directory?: string;
 }
 
 /**
@@ -33,7 +35,7 @@ async function main() {
     const input = await readStdin();
     const data: HookInput = JSON.parse(input) as HookInput;
 
-    const { prompt, session_id, working_directory } = data;
+    const { prompt, session_id } = data;
 
     // initialize hook context
     const {
@@ -42,7 +44,8 @@ async function main() {
       config,
       logger: contextLogger,
     } = initHookContext({
-      workingDirectory: working_directory,
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
 

--- a/packages/create-auto-loading-claude-skills/src/templates/hooks/stop-validator.ts
+++ b/packages/create-auto-loading-claude-skills/src/templates/hooks/stop-validator.ts
@@ -3,6 +3,7 @@ import {
   handleHookError,
   initHookContext,
   readStdin,
+  resolveHookDir,
   RuleMatcher,
   sessionState,
 } from "@satoshibits/claude-skill-runtime";
@@ -11,7 +12,8 @@ import type { DebugLogger, StopMatch } from "@satoshibits/claude-skill-runtime";
 
 interface StopHookInput {
   session_id: string;
-  working_directory: string;
+  cwd?: string;
+  working_directory?: string;
   stop_hook_active?: boolean;
   transcript_summary?: string;
 }
@@ -27,7 +29,7 @@ async function main() {
     const input = await readStdin();
     const data: StopHookInput = JSON.parse(input) as StopHookInput;
 
-    const { session_id, working_directory, transcript_summary } = data;
+    const { session_id, transcript_summary } = data;
 
     // initialize hook context
     const {
@@ -36,7 +38,8 @@ async function main() {
       config,
       logger: contextLogger,
     } = initHookContext({
-      workingDirectory: working_directory,
+      cwd: resolveHookDir(data),
+      userScope: true,
     });
     logger = contextLogger;
 

--- a/packages/create-auto-loading-claude-skills/src/types/cli-options.ts
+++ b/packages/create-auto-loading-claude-skills/src/types/cli-options.ts
@@ -27,6 +27,8 @@ export interface WizardOptions {
 export interface ValidateOptions {
   fix?: boolean;
   verbose?: boolean;
+  /** Apply --fix repairs without prompting — required for non-interactive use. */
+  yes?: boolean;
 }
 
 export interface SyncOptions {

--- a/packages/create-auto-loading-claude-skills/src/utils/document-discovery.ts
+++ b/packages/create-auto-loading-claude-skills/src/utils/document-discovery.ts
@@ -2,6 +2,8 @@ import { glob } from "glob";
 import fs from "fs";
 import path from "path";
 
+import { resolveSkillFile } from "./skill-paths.js";
+
 export interface DocMatch {
   path: string;
   confidence: number;
@@ -92,15 +94,12 @@ export class DocumentDiscovery {
     resources?: { name: string; isSymlink: boolean; target: string | null }[];
     lastModified?: Date;
   } {
-    const skillPath = path.join(
-      this.projectDir,
-      ".claude",
-      "skills",
-      skillName,
-      "SKILL.md",
-    );
+    // resolve either casing via the shared predicate, so a lowercase skill.md is detected
+    // and the AI add-skill flow doesn't create a duplicate uppercase file beside it
+    const skillsDir = path.join(this.projectDir, ".claude", "skills");
+    const skillPath = resolveSkillFile(skillsDir, skillName);
 
-    if (fs.existsSync(skillPath)) {
+    if (skillPath) {
       return {
         exists: true,
         content: fs.readFileSync(skillPath, "utf8"),

--- a/packages/create-auto-loading-claude-skills/src/utils/skill-paths.ts
+++ b/packages/create-auto-loading-claude-skills/src/utils/skill-paths.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * The canonical filename casings a skill's definition may use.
+ *
+ * Skills are discovered with a case-insensitive glob, so any code that later checks a
+ * skill's existence or reads its content must accept the same casings — otherwise, on a
+ * case-sensitive filesystem, a lowercase `skill.md` skill syncs and validates cleanly but
+ * is treated as missing everywhere else ("scored but silently never surfaces").
+ */
+const SKILL_FILENAMES = ["SKILL.md", "skill.md"] as const;
+
+/**
+ * Resolve a skill's definition file, or null if none exists.
+ *
+ * This is the SINGLE resolution primitive — `skillExists`, sync's drop predicate,
+ * validate's orphan check, and the add-skill existence guard all funnel through it, so the
+ * "which files count as this skill" invariant cannot drift between call sites.
+ */
+export function resolveSkillFile(
+  skillsDir: string,
+  name: string,
+): string | null {
+  for (const file of SKILL_FILENAMES) {
+    const candidate = path.join(skillsDir, name, file);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Does a skill's definition file exist on disk (either casing)?
+ */
+export function skillExists(skillsDir: string, name: string): boolean {
+  return resolveSkillFile(skillsDir, name) !== null;
+}

--- a/packages/create-auto-loading-claude-skills/tests/commands/pipeline-composition.test.ts
+++ b/packages/create-auto-loading-claude-skills/tests/commands/pipeline-composition.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Composition test: sync → sync-status → validate → hook resolution.
+ *
+ * Every unit in this pipeline passed its own tests while the pipeline itself was broken:
+ * `sync` wrote rules `validate` rejected as orphaned and the runtime could not load, and
+ * `sync-status` reported "stale" immediately after a clean `sync`. Only an end-to-end
+ * fixture catches that class of defect.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(__dirname, "../../dist/src/bin/cli.js");
+const HOOK = path.join(
+  __dirname,
+  "../../dist/src/templates/hooks/skill-activation-prompt.js",
+);
+
+const SKILL_MD = (name: string, keyword: string) => `---
+name: ${name}
+description: ${name} description
+x-smart-triggers:
+  activationStrategy: suggestive
+  promptTriggers:
+    keywords:
+      - ${keyword}
+---
+
+# ${name}
+`;
+
+describe("sync → sync-status → validate → hook pipeline", () => {
+  let projectDir: string;
+  let homeDir: string;
+
+  function run(args: string, cwd: string): { stdout: string; code: number } {
+    const r = spawnSync("node", [CLI, ...args.split(" ")], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+    });
+    return { stdout: (r.stdout ?? "") + (r.stderr ?? ""), code: r.status ?? 1 };
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "pipeline-proj-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pipeline-home-"));
+    fs.mkdirSync(path.join(homeDir, ".claude", "skills"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("a project skill survives the whole pipeline", () => {
+    // authored in the documented location
+    const dir = path.join(projectDir, ".claude", "skills", "proj-tool");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "SKILL.md"), SKILL_MD("proj-tool", "deploy"));
+
+    run("sync", projectDir);
+    // assert on the artifact, not the console summary
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+        "utf8",
+      ),
+    ).toContain("proj-tool");
+
+    // sync-status must not report stale immediately after a clean sync
+    const status = run("sync-status", projectDir);
+    expect(status.code).toBe(0);
+
+    // validate must not call the freshly-synced rule orphaned
+    const validated = run("validate", projectDir);
+    expect(validated.stdout).not.toContain("SKILL.md not found");
+    expect(validated.code).toBe(0);
+
+    // and the hook must actually resolve it
+    const hook = spawnSync("node", [HOOK], {
+      input: JSON.stringify({
+        cwd: projectDir,
+        session_id: "pipeline-1",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "help me deploy",
+      }),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        CLAUDE_PROJECT_DIR: undefined as unknown as string,
+      },
+    });
+    expect(hook.stdout).toContain("proj-tool");
+  });
+
+  it("a personal skill survives the pipeline when synced from home", () => {
+    const dir = path.join(homeDir, ".claude", "skills", "personal-tool");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "SKILL.md"),
+      SKILL_MD("personal-tool", "personal"),
+    );
+
+    run("sync", homeDir);
+    expect(
+      fs.readFileSync(
+        path.join(homeDir, ".claude/skills/skill-rules.yaml"),
+        "utf8",
+      ),
+    ).toContain("personal-tool");
+
+    const status = run("sync-status", homeDir);
+    expect(status.code).toBe(0);
+
+    const validated = run("validate", homeDir);
+    expect(validated.code).toBe(0);
+
+    // resolvable from an unrelated project via user scope
+    const hook = spawnSync("node", [HOOK], {
+      input: JSON.stringify({
+        cwd: projectDir,
+        session_id: "pipeline-2",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "a personal matter",
+      }),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        CLAUDE_PROJECT_DIR: undefined as unknown as string,
+      },
+    });
+    expect(hook.stdout).toContain("personal-tool");
+  });
+
+  it("clears synced entries when the last SKILL.md is deleted, instead of deadlocking", () => {
+    // sync used to return early on zero skill files, so a config whose skills were all
+    // deleted stayed stale forever and `sync` refused to repair it
+    const dir = path.join(projectDir, ".claude", "skills", "doomed");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "SKILL.md"), SKILL_MD("doomed", "deploy"));
+
+    run("sync", projectDir);
+    expect(run("sync-status", projectDir).code).toBe(0);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    run("sync", projectDir);
+
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+        "utf8",
+      ),
+    ).not.toContain("doomed");
+    expect(run("sync-status", projectDir).code).toBe(0);
+  });
+
+  it("drops personal entries an older release copied into a project config", () => {
+    // migration: preserving them as "manual" would keep the shadowing bug alive
+    fs.mkdirSync(path.join(projectDir, ".claude", "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+      `version: "2.0"
+skills:
+  personal-tool:
+    type: domain
+    enforcement: suggest
+    priority: high
+    description: "copied by an older sync"
+    promptTriggers:
+      keywords: [personal]
+_sync:
+  skillScopes:
+    personal-tool: personal
+`,
+      "utf8",
+    );
+
+    run("sync", projectDir);
+
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+        "utf8",
+      ),
+    ).not.toContain("personal-tool");
+  });
+
+  it("syncing a project does not report personal skills as stale afterwards", () => {
+    const personal = path.join(homeDir, ".claude", "skills", "personal-tool");
+    fs.mkdirSync(personal, { recursive: true });
+    fs.writeFileSync(
+      path.join(personal, "SKILL.md"),
+      SKILL_MD("personal-tool", "personal"),
+    );
+    const proj = path.join(projectDir, ".claude", "skills", "proj-tool");
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, "SKILL.md"), SKILL_MD("proj-tool", "deploy"));
+
+    run("sync", projectDir);
+
+    // the read path must apply the same scope filter as the write path
+    const status = run("sync-status", projectDir);
+    expect(status.code).toBe(0);
+  });
+});
+
+describe("sync drop predicate is gated on file existence", () => {
+  let projectDir: string;
+  let homeDir: string;
+
+  function run(args: string, cwd: string): { stdout: string; code: number } {
+    const r = spawnSync("node", [CLI, ...args.split(" ")], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+    });
+    return { stdout: (r.stdout ?? "") + (r.stderr ?? ""), code: r.status ?? 1 };
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "drop-proj-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "drop-home-"));
+    fs.mkdirSync(path.join(homeDir, ".claude", "skills"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  function writeSkill(name: string, keyword: string): void {
+    const dir = path.join(projectDir, ".claude", "skills", name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "SKILL.md"),
+      `---\nname: ${name}\ndescription: ${name}\nx-smart-triggers:\n  activationStrategy: suggestive\n  promptTriggers:\n    keywords: [${keyword}]\n---\n\n# ${name}\n`,
+    );
+  }
+
+  const rulesFile = () =>
+    fs.readFileSync(
+      path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+      "utf8",
+    );
+
+  it("preserves a rule whose SKILL.md still exists but failed to parse", () => {
+    writeSkill("kept", "kept");
+    writeSkill("broken", "broken");
+    run("sync", projectDir);
+    expect(rulesFile()).toContain("broken");
+
+    // corrupt the frontmatter — the FILE still exists
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/broken/SKILL.md"),
+      "not: [valid yaml\n",
+    );
+    const result = run("sync", projectDir);
+
+    // not dropped, and not misdiagnosed as "SKILL.md no longer exists"
+    expect(rulesFile()).toContain("broken");
+    expect(result.stdout).not.toContain("no longer exists");
+  });
+
+  it("keeps a transiently-broken synced skill sync-owned, so a LATER deletion still drops it", () => {
+    // regression: preserving a parse-error skill as "manual" dropped its scope metadata,
+    // permanently defeating the stale-drop — a clean → corrupt → delete sequence left the
+    // rule lingering forever
+    writeSkill("survivor", "survivor");
+    run("sync", projectDir);
+
+    // corrupt (file present) — rule preserved, must stay sync-owned
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/survivor/SKILL.md"),
+      "not: [valid yaml\n",
+    );
+    run("sync", projectDir);
+    expect(rulesFile()).toContain("survivor");
+
+    // now delete the file entirely — the drop must fire because scope was carried forward
+    fs.rmSync(path.join(projectDir, ".claude/skills/survivor"), {
+      recursive: true,
+      force: true,
+    });
+    const result = run("sync", projectDir);
+
+    expect(rulesFile()).not.toContain("survivor");
+    expect(result.stdout).toContain("no longer exists");
+  });
+
+  it("drops a rule only when its SKILL.md is genuinely gone", () => {
+    writeSkill("doomed", "doomed");
+    run("sync", projectDir);
+    expect(rulesFile()).toContain("doomed");
+
+    fs.rmSync(path.join(projectDir, ".claude/skills/doomed"), {
+      recursive: true,
+      force: true,
+    });
+    const result = run("sync", projectDir);
+
+    expect(rulesFile()).not.toContain("doomed");
+    expect(result.stdout).toContain("no longer exists");
+  });
+});

--- a/packages/create-auto-loading-claude-skills/tests/commands/sync-command.test.ts
+++ b/packages/create-auto-loading-claude-skills/tests/commands/sync-command.test.ts
@@ -38,7 +38,7 @@ describe("sync command", () => {
   });
 
   describe("syncCommand", () => {
-    it("should handle empty project (no .claude/commands/)", async () => {
+    it("should handle empty project (no .claude/skills/)", async () => {
       await syncCommand({ verbose: false });
 
       // should not create skill-rules.yaml
@@ -53,7 +53,7 @@ describe("sync command", () => {
 
     it("should sync skills with x-smart-triggers", async () => {
       // create skill with x-smart-triggers
-      const skillDir = path.join(testDir, ".claude", "commands", "terraform");
+      const skillDir = path.join(testDir, ".claude", "skills", "terraform");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent = `---
@@ -118,7 +118,7 @@ This skill helps with Terraform apply operations.
 
     it("should skip skills without x-smart-triggers", async () => {
       // create skill without x-smart-triggers
-      const skillDir = path.join(testDir, ".claude", "commands", "simple");
+      const skillDir = path.join(testDir, ".claude", "skills", "simple");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent = `---
@@ -179,7 +179,7 @@ Just a simple skill.
       );
 
       // create a new skill with x-smart-triggers
-      const skillDir = path.join(testDir, ".claude", "commands", "new-skill");
+      const skillDir = path.join(testDir, ".claude", "skills", "new-skill");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent = `---
@@ -214,7 +214,7 @@ x-smart-triggers:
 
     it("should respect dry-run option", async () => {
       // create skill with x-smart-triggers
-      const skillDir = path.join(testDir, ".claude", "commands", "test-skill");
+      const skillDir = path.join(testDir, ".claude", "skills", "test-skill");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent = `---
@@ -242,7 +242,7 @@ x-smart-triggers:
 
     it("should include sync metadata", async () => {
       // create skill with x-smart-triggers
-      const skillDir = path.join(testDir, ".claude", "commands", "meta-skill");
+      const skillDir = path.join(testDir, ".claude", "skills", "meta-skill");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent = `---
@@ -280,7 +280,7 @@ x-smart-triggers:
   describe("checkSyncStatus", () => {
     it("should report stale when SKILL.md changed after sync", async () => {
       // create and sync a skill
-      const skillDir = path.join(testDir, ".claude", "commands", "stale-test");
+      const skillDir = path.join(testDir, ".claude", "skills", "stale-test");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent1 = `---
@@ -342,7 +342,7 @@ x-smart-triggers:
 
     it("should report not stale when no changes", async () => {
       // create and sync a skill
-      const skillDir = path.join(testDir, ".claude", "commands", "stable-test");
+      const skillDir = path.join(testDir, ".claude", "skills", "stable-test");
       fs.mkdirSync(skillDir, { recursive: true });
 
       const skillContent = `---
@@ -398,12 +398,47 @@ x-smart-triggers:
       const config = yaml.load(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
       const skills = config.skills as Record<string, unknown>;
 
-      expect(skills["personal-tool"]).toBeDefined();
+      // personal skills are deliberately NOT written into a project config: content is
+      // resolved only from the scope that declared a rule, so a project-declared copy
+      // would point at <project>/.claude/skills/personal-tool (which does not exist) and
+      // would shadow the working user-scope entry. Sync from the home dir instead.
+      expect(skills?.["personal-tool"]).toBeUndefined();
+    });
 
-      // check sync metadata tracks scope
+    it("should write personal skills when syncing the home directory itself", async () => {
+      const personalSkillDir = path.join(fakeHomeDir, ".claude", "skills", "home-tool");
+      fs.mkdirSync(personalSkillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(personalSkillDir, "SKILL.md"),
+        `---
+name: home-tool
+description: A personal tool skill
+x-smart-triggers:
+  activationStrategy: suggestive
+  promptTriggers:
+    keywords:
+      - personal
+---
+
+# Home Tool
+`,
+      );
+
+      const previousCwd = process.cwd();
+      process.chdir(fakeHomeDir);
+      try {
+        await syncCommand({ verbose: false });
+      } finally {
+        process.chdir(previousCwd);
+      }
+
+      const configPath = path.join(fakeHomeDir, ".claude", "skills", "skill-rules.yaml");
+      const config = yaml.load(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+      const skills = config.skills as Record<string, unknown>;
+
+      expect(skills["home-tool"]).toBeDefined();
       const sync = config._sync as Record<string, unknown>;
-      expect(sync.skillScopes).toBeDefined();
-      expect((sync.skillScopes as Record<string, string>)["personal-tool"]).toBe("personal");
+      expect((sync.skillScopes as Record<string, string>)["home-tool"]).toBe("personal");
     });
 
     it("should have project skills override personal skills with same name", async () => {
@@ -427,7 +462,7 @@ x-smart-triggers:
       fs.writeFileSync(path.join(personalSkillDir, "SKILL.md"), personalSkillContent);
 
       // create project skill with same name
-      const projectSkillDir = path.join(testDir, ".claude", "commands", "override-test");
+      const projectSkillDir = path.join(testDir, ".claude", "skills", "override-test");
       fs.mkdirSync(projectSkillDir, { recursive: true });
 
       const projectSkillContent = `---
@@ -481,7 +516,7 @@ x-smart-triggers:
       fs.writeFileSync(path.join(personalSkillDir, "SKILL.md"), personalSkillContent);
 
       // create project skill with different name
-      const projectSkillDir = path.join(testDir, ".claude", "commands", "project-only");
+      const projectSkillDir = path.join(testDir, ".claude", "skills", "project-only");
       fs.mkdirSync(projectSkillDir, { recursive: true });
 
       const projectSkillContent = `---
@@ -502,13 +537,13 @@ x-smart-triggers:
       const config = yaml.load(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
       const skills = config.skills as Record<string, unknown>;
 
-      expect(skills["personal-only"]).toBeDefined();
+      // only the project skill lands in a project config; the personal one stays in
+      // ~/.claude/skills where the runtime can actually resolve its SKILL.md
       expect(skills["project-only"]).toBeDefined();
+      expect(skills["personal-only"]).toBeUndefined();
 
-      // check scopes are tracked correctly
       const sync = config._sync as Record<string, unknown>;
       const scopes = sync.skillScopes as Record<string, string>;
-      expect(scopes["personal-only"]).toBe("personal");
       expect(scopes["project-only"]).toBe("project");
     });
 
@@ -518,7 +553,7 @@ x-smart-triggers:
       fs.mkdirSync(personalDir, { recursive: true });
 
       // create project skill
-      const projectSkillDir = path.join(testDir, ".claude", "commands", "project-skill");
+      const projectSkillDir = path.join(testDir, ".claude", "skills", "project-skill");
       fs.mkdirSync(projectSkillDir, { recursive: true });
 
       const projectSkillContent = `---
@@ -546,7 +581,7 @@ x-smart-triggers:
       // don't create any personal directory - it shouldn't exist
 
       // create project skill
-      const projectSkillDir = path.join(testDir, ".claude", "commands", "project-skill");
+      const projectSkillDir = path.join(testDir, ".claude", "skills", "project-skill");
       fs.mkdirSync(projectSkillDir, { recursive: true });
 
       const projectSkillContent = `---
@@ -569,5 +604,56 @@ x-smart-triggers:
 
       expect(skills["project-skill"]).toBeDefined();
     });
+  });
+});
+
+describe("legacy .claude/commands/ location", () => {
+  it("warns about SKILL.md files there instead of syncing them", async () => {
+    // syncing them produced rules no reader could resolve: `validate` reported them as
+    // orphaned and the runtime returned null for their content
+    const tmp = fs.mkdtempSync("/tmp/legacy-commands-");
+    const prevCwd = process.cwd();
+    const prevHome = process.env.HOME;
+    const home = fs.mkdtempSync("/tmp/legacy-home-");
+    try {
+      fs.mkdirSync(path.join(tmp, ".claude", "commands", "legacy"), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(tmp, ".claude", "commands", "legacy", "SKILL.md"),
+        `---
+name: legacy
+description: legacy
+x-smart-triggers:
+  activationStrategy: suggestive
+  promptTriggers:
+    keywords: [legacy]
+---
+
+# legacy
+`,
+      );
+      process.chdir(tmp);
+      process.env.HOME = home;
+
+      const logs: string[] = [];
+      const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+        logs.push(args.join(" "));
+      });
+      await syncCommand({ verbose: false });
+      spy.mockRestore();
+
+      expect(logs.join("\n")).toContain(".claude/commands/");
+      const configPath = path.join(tmp, ".claude", "skills", "skill-rules.yaml");
+      if (fs.existsSync(configPath)) {
+        expect(fs.readFileSync(configPath, "utf8")).not.toContain("legacy");
+      }
+    } finally {
+      process.chdir(prevCwd);
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/create-auto-loading-claude-skills/tests/commands/validation-command.test.ts
+++ b/packages/create-auto-loading-claude-skills/tests/commands/validation-command.test.ts
@@ -4,6 +4,7 @@
  */
 
 import fs from "fs";
+import yaml from "js-yaml";
 import path from "path";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
@@ -71,16 +72,31 @@ describe("Validate command", () => {
   }
 
   describe("Valid configurations", () => {
+    /** A rule is only valid if its SKILL.md exists — otherwise it is an orphan. */
+    function createSkillFile(name: string): void {
+      fs.mkdirSync(path.join(skillsDir, name), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, name, "SKILL.md"),
+        `---\nname: ${name}\ndescription: test skill\n---\n\n# ${name}\n`,
+        "utf8",
+      );
+    }
+
     it("should validate a correct skill-rules.yaml", () => {
+      createSkillFile("error-handling");
       fs.writeFileSync(
         path.join(skillsDir, "skill-rules.yaml"),
+        // all four schema-required fields present — this fixture previously omitted
+        // enforcement and description, so it was never actually a "correct" config
         `version: "1.0"
 settings:
   maxSuggestions: 3
 skills:
   error-handling:
     type: domain
+    enforcement: suggest
     priority: high
+    description: "Error handling patterns"
     promptTriggers:
       keywords: [error, exception]
 `,
@@ -89,10 +105,11 @@ skills:
 
       const result = runValidate();
       expect(result.exitCode).toBe(0);
-      expect(result.stdout.includes("valid") || !result.stderr).toBe(true);
+      expect(result.stdout).toContain("1 valid skill(s)");
     });
 
     it("should validate skill-rules.json", () => {
+      createSkillFile("api-design");
       fs.writeFileSync(
         path.join(skillsDir, "skill-rules.json"),
         JSON.stringify(
@@ -102,7 +119,9 @@ skills:
             skills: {
               "api-design": {
                 type: "domain",
+                enforcement: "suggest",
                 priority: "medium",
+                description: "API design patterns",
                 promptTriggers: { keywords: ["API", "endpoint"] },
               },
             },
@@ -134,10 +153,12 @@ skills:
       );
 
       const result = runValidate();
-      expect(
-        result.stdout.includes("orphan") ||
-          result.stdout.includes("missing-skill"),
-      ).toBe(true);
+      // assert the DIAGNOSIS, not the skill's name — the old disjunction passed on
+      // `includes("missing-skill")`, which any mention of the rule satisfies
+      expect(result.stdout).toContain(
+        "Referenced in skill-rules but SKILL.md not found",
+      );
+      expect(result.exitCode).not.toBe(0);
     });
 
     it("should detect invalid YAML syntax", () => {
@@ -200,7 +221,9 @@ settings:
 skills:
   valid-skill:
     type: domain
+    enforcement: suggest
     priority: medium
+    description: "A properly configured skill"
     promptTriggers:
       keywords: [test]
 `,
@@ -217,134 +240,34 @@ skills:
       );
 
       const result = runValidate();
-      expect(result.stdout.includes("valid") || result.exitCode === 0).toBe(true);
+      // exitCode is the only load-bearing signal here: `includes("valid")` matches the
+      // skill's own name, and runValidate hardcodes stderr to "" on success
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("1 valid skill(s)");
     });
   });
 
   describe("Auto-fix functionality", () => {
-    it("should fix missing settings with --fix flag", () => {
+    it("treats a missing settings block as valid (settings are optional)", () => {
+      // NOTE: this replaces a test named "should fix missing settings with --fix flag".
+      // There is no settings auto-fix in the codebase; that test asserted
+      // `content.includes("settings") || exitCode === 0` and passed purely on the second
+      // disjunct, which was 0 only because --fix silently did nothing.
+      fs.mkdirSync(path.join(skillsDir, "test-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "test-skill", "SKILL.md"),
+        "---\nname: test-skill\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
       fs.writeFileSync(
         path.join(skillsDir, "skill-rules.yaml"),
         `version: "1.0"
 skills:
   test-skill:
     type: domain
+    enforcement: suggest
     priority: medium
-    promptTriggers:
-      keywords: [test]
-`,
-        "utf8",
-      );
-
-      const result = runValidate("--fix");
-
-      // read the fixed file
-      const content = fs.readFileSync(
-        path.join(skillsDir, "skill-rules.yaml"),
-        "utf8",
-      );
-
-      expect(content.includes("settings") || result.exitCode === 0).toBe(true);
-    });
-
-    it("should remove orphaned skill entries with --fix flag", () => {
-      // create skill-rules with orphaned skill (no matching SKILL.md)
-      fs.writeFileSync(
-        path.join(skillsDir, "skill-rules.yaml"),
-        `version: "1.0"
-settings:
-  maxSuggestions: 3
-skills:
-  orphaned-skill:
-    type: domain
-    priority: high
-    promptTriggers:
-      keywords: [orphan]
-  valid-skill:
-    type: domain
-    priority: medium
-    promptTriggers:
-      keywords: [valid]
-`,
-        "utf8",
-      );
-
-      // create SKILL.md only for valid-skill
-      const validSkillDir = path.join(skillsDir, "valid-skill");
-      fs.mkdirSync(validSkillDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(validSkillDir, "SKILL.md"),
-        "# Valid Skill\nThis skill has matching SKILL.md",
-        "utf8",
-      );
-
-      const result = runValidate("--fix");
-
-      // read the fixed file
-      const content = fs.readFileSync(
-        path.join(skillsDir, "skill-rules.yaml"),
-        "utf8",
-      );
-
-      // orphaned skill should be removed or warned about
-      expect(
-        !content.includes("orphaned-skill") ||
-          result.stdout.includes("removed") ||
-          result.stdout.includes("orphan"),
-      ).toBe(true);
-
-      // valid skill should remain
-      expect(content.includes("valid-skill")).toBe(true);
-    });
-
-    it("should add unregistered skills with --fix flag", () => {
-      // create minimal skill-rules
-      fs.writeFileSync(
-        path.join(skillsDir, "skill-rules.yaml"),
-        `version: "1.0"
-settings:
-  maxSuggestions: 3
-skills: {}
-`,
-        "utf8",
-      );
-
-      // create unregistered skill directory with SKILL.md
-      const unregSkillDir = path.join(skillsDir, "unregistered-skill");
-      fs.mkdirSync(unregSkillDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(unregSkillDir, "SKILL.md"),
-        "# Unregistered Skill\nThis skill exists but needs to be registered",
-        "utf8",
-      );
-
-      const result = runValidate("--fix");
-
-      // read the fixed file
-      const content = fs.readFileSync(
-        path.join(skillsDir, "skill-rules.yaml"),
-        "utf8",
-      );
-
-      // unregistered skill should be added or reported
-      expect(
-        content.includes("unregistered-skill") ||
-          result.stdout.includes("added") ||
-          result.stdout.includes("registered"),
-      ).toBe(true);
-    });
-
-    it("should handle schema validation errors", () => {
-      // create skill-rules with invalid schema (missing required fields)
-      fs.writeFileSync(
-        path.join(skillsDir, "skill-rules.yaml"),
-        `version: "1.0"
-settings:
-  maxSuggestions: 3
-skills:
-  invalid-skill:
-    # missing required 'type' field
-    priority: high
+    description: "no settings block present"
     promptTriggers:
       keywords: [test]
 `,
@@ -353,14 +276,318 @@ skills:
 
       const result = runValidate();
 
-      // should report schema validation error
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain("error(s)");
+    });
+
+    it("removes the orphaned entry with --fix --yes, and the file proves it", () => {
+      // Previously asserted `!content.includes(...) || stdout.includes("orphan")`, which
+      // passed on the word "orphan" appearing in the ERROR listing while the repair path
+      // never executed. --yes makes the repair reachable non-interactively.
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  orphaned-skill:
+    type: domain
+    enforcement: suggest
+    priority: high
+    description: "no SKILL.md on disk"
+    promptTriggers:
+      keywords: [test]
+`,
+        "utf8",
+      );
+
+      const result = runValidate("--fix --yes");
+
+      const after = fs.readFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        "utf8",
+      );
+      expect(after).not.toContain("orphaned-skill"); // the observable
+      expect(result.stdout).toContain("Removed: orphaned-skill");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("adds the unregistered skill with --fix --yes, and the file proves it", () => {
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills: {}
+`,
+        "utf8",
+      );
+      fs.mkdirSync(path.join(skillsDir, "new-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "new-skill", "SKILL.md"),
+        "---\nname: new-skill\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+
+      const result = runValidate("--fix --yes");
+
+      const after = fs.readFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        "utf8",
+      );
+      expect(after).toContain("new-skill");
+      expect(result.stdout).toContain("Added: new-skill");
+    });
+
+    it("does not delete a malformed rule the user was told to fix by hand", () => {
+      // the crash guard used to mutate the same config object that --fix serializes, so
+      // `bare-skill` silently vanished while the output said to edit it manually
+      fs.mkdirSync(path.join(skillsDir, "kept-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "kept-skill", "SKILL.md"),
+        "---\nname: kept-skill\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  kept-skill:
+    type: domain
+    enforcement: suggest
+    priority: high
+    description: "fine"
+    promptTriggers:
+      keywords: [test]
+  bare-skill:
+`,
+        "utf8",
+      );
+
+      // an UNREGISTERED skill forces auto-fix to actually serialize the config —
+      // without a write, the assertion below would pass on a file nobody touched
+      fs.mkdirSync(path.join(skillsDir, "extra-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "extra-skill", "SKILL.md"),
+        "---\nname: extra-skill\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+
+      const result = runValidate("--fix --yes");
+
+      const after = fs.readFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        "utf8",
+      );
+      expect(result.stdout).toContain("Added: extra-skill"); // proves a write happened
+      expect(after).toContain("bare-skill"); // survives — it is the user's data
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it("should still exit non-zero when --fix cannot repair the errors", () => {
+      // --fix repairs orphaned/unregistered entries and missing settings, but not schema
+      // errors inside a rule. Exiting 0 there would let a CI job pass with a config whose
+      // skills can never fire.
+      fs.mkdirSync(path.join(skillsDir, "unfixable-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "unfixable-skill", "SKILL.md"),
+        "---\nname: unfixable-skill\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  unfixable-skill:
+    priority: high
+    promptTriggers:
+      keywords: [test]
+`,
+        "utf8",
+      );
+
+      const result = runValidate("--fix --yes");
+
+      expect(result.stdout).not.toContain("interactive terminal"); // repair path ran
+      expect(result.stdout).toContain("remain after auto-fix");
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it("refuses to auto-fix when stdin is not a TTY, and fails the run", () => {
+      // `prompts` gates every repair behind an interactive confirm; on a closed stdin it
+      // aborts and terminates the process from inside the prompt, so nothing is repaired
+      // and no later code runs. Previously that combination exited 0 — an open CI gate.
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+settings:
+  maxSuggestions: 3
+skills:
+  ghost-skill:
+    priority: high
+    promptTriggers:
+      keywords: [test]
+`,
+        "utf8",
+      );
+
+      const result = runValidate("--fix");
+
+      expect(result.stdout).toContain("requires an interactive terminal");
+      expect(result.exitCode).not.toBe(0);
+      // the observable that matters: the file was NOT modified
+      const after = fs.readFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        "utf8",
+      );
+      expect(after).toContain("ghost-skill");
+    });
+
+    it("reports a null rule entry instead of crashing", () => {
+      // `my-skill:` with no body parses to null; property access used to throw
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  empty-rule:
+`,
+        "utf8",
+      );
+
+      const result = runValidate();
+
+      expect(result.stdout).toContain("Rule is empty");
+      expect(result.stdout).not.toContain("TypeError");
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it("repairs a config with an absent skills block instead of crashing", () => {
+      // `skills` absent is normalizable — but auto-fix used to assign into `undefined`.
+      // Distinct from present-but-malformed, which must be refused.
+      fs.mkdirSync(path.join(skillsDir, "new-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "new-skill", "SKILL.md"),
+        "---\nname: new-skill\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"\n`,
+        "utf8",
+      );
+
+      const result = runValidate("--fix --yes");
+
+      expect(result.stdout).not.toContain("TypeError");
+      expect(result.stdout).not.toContain("Refusing to auto-fix");
       expect(
-        result.stdout.includes("type") ||
-          result.stdout.includes("required") ||
-          result.stdout.includes("invalid") ||
-          result.stderr.includes("type") ||
-          result.exitCode !== 0,
-      ).toBe(true);
+        fs.readFileSync(path.join(skillsDir, "skill-rules.yaml"), "utf8"),
+      ).toContain("new-skill");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("refuses to auto-fix a present-but-malformed skills block, preserving it", () => {
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  - name: legacy-one
+  - name: legacy-two
+`,
+        "utf8",
+      );
+
+      const result = runValidate("--fix --yes");
+
+      expect(result.stdout).toContain("Refusing to auto-fix");
+      expect(
+        fs.readFileSync(path.join(skillsDir, "skill-rules.yaml"), "utf8"),
+      ).toContain("legacy-one"); // the user's data survives
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it("rejects a scalar or array at the top level instead of crashing", () => {
+      // yaml.load returns a primitive; the truthiness check passed and assigning
+      // `.skills` onto it threw a TypeError
+      for (const body of ["true\n", "\"oops\"\n", "- a\n- b\n"]) {
+        fs.writeFileSync(path.join(skillsDir, "skill-rules.yaml"), body, "utf8");
+        const result = runValidate();
+        expect(result.stdout).not.toContain("TypeError");
+        expect(result.stdout).toContain("must be a mapping at the top level");
+        expect(result.exitCode).not.toBe(0);
+      }
+    });
+
+    it("accepts a config with no skills block at all", () => {
+      // structurally valid YAML; Object.keys(undefined) used to throw
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+settings:
+  maxSuggestions: 3
+`,
+        "utf8",
+      );
+
+      const result = runValidate();
+
+      expect(result.stdout).not.toContain("TypeError");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("does not flag a rule that has empty keywords but real intentPatterns", () => {
+      // `??` short-circuits on false, so the intentPatterns branch was never consulted
+      fs.mkdirSync(path.join(skillsDir, "mixed-triggers"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "mixed-triggers", "SKILL.md"),
+        "---\nname: mixed-triggers\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  mixed-triggers:
+    type: domain
+    enforcement: suggest
+    priority: high
+    description: "has intent patterns only"
+    promptTriggers:
+      keywords: []
+      intentPatterns: ["deploy.*staging"]
+`,
+        "utf8",
+      );
+
+      const result = runValidate();
+
+      expect(result.stdout).not.toContain("no triggers defined");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reject an activationStrategy outside the enum", () => {
+      fs.mkdirSync(path.join(skillsDir, "bad-strategy"), { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, "bad-strategy", "SKILL.md"),
+        "---\nname: bad-strategy\ndescription: test\n---\n# test\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(skillsDir, "skill-rules.yaml"),
+        `version: "1.0"
+skills:
+  bad-strategy:
+    type: workflow
+    enforcement: suggest
+    priority: high
+    description: "test"
+    activationStrategy: imperative
+    promptTriggers:
+      keywords: [test]
+`,
+        "utf8",
+      );
+
+      const result = runValidate();
+
+      expect(result.stdout).toContain("Invalid activationStrategy: imperative");
+      expect(result.exitCode).not.toBe(0);
     });
   });
 
@@ -387,5 +614,91 @@ skills:
                          result.stderr.toLowerCase().includes("invalid");
       expect(hasError || hasWarning).toBe(true);
     });
+  });
+});
+
+/**
+ * `validate` hand-maintains the list of known/required rule fields. Nothing binds those
+ * lists to schema/skill-rules.schema.json, so adding a property to the schema would make
+ * every valid config emit a spurious "Unknown field" warning. Bind them here.
+ */
+describe("validate stays in sync with the JSON schema", () => {
+  const schemaPath = path.join(__dirname, "../../schema/skill-rules.schema.json");
+
+  function skillRuleSchema(): {
+    properties: Record<string, unknown>;
+    required: string[];
+  } {
+    const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8")) as unknown;
+    let found: { properties: Record<string, unknown>; required: string[] } | null = null;
+    const walk = (node: unknown): void => {
+      if (found || !node || typeof node !== "object") return;
+      const obj = node as Record<string, unknown>;
+      const props = obj.properties as Record<string, unknown> | undefined;
+      if (props && "enforcement" in props && "priority" in props) {
+        found = {
+          properties: props,
+          required: (obj.required as string[] | undefined) ?? [],
+        };
+        return;
+      }
+      Object.values(obj).forEach(walk);
+    };
+    walk(schema);
+    if (!found) throw new Error("SkillRule definition not found in schema");
+    return found;
+  }
+
+  it("accepts a rule using every property the schema allows", () => {
+    const tmp = fs.mkdtempSync("/tmp/schema-sync-");
+    const skills = path.join(tmp, ".claude", "skills");
+    fs.mkdirSync(path.join(skills, "everything"), { recursive: true });
+    fs.writeFileSync(
+      path.join(skills, "everything", "SKILL.md"),
+      "---\nname: everything\ndescription: test\n---\n# test\n",
+      "utf8",
+    );
+
+    const { properties, required } = skillRuleSchema();
+
+    // bind the schema's required list to validate.ts's hand-rolled requiredFields
+    expect([...required].sort()).toEqual(
+      ["description", "enforcement", "priority", "type"].sort(),
+    );
+    const rule: Record<string, unknown> = {
+      type: "domain",
+      enforcement: "suggest",
+      priority: "high",
+      description: "uses every schema property",
+      activationStrategy: "suggestive",
+      cooldownMinutes: 5,
+      promptTriggers: { keywords: ["x"] },
+      fileTriggers: { pathPatterns: ["**/*.ts"] },
+      preToolTriggers: { toolName: "Bash" },
+      shadowTriggers: { keywords: ["y"] },
+      stopTriggers: { keywords: ["z"] },
+      promptHook: { type: "prompt", prompt: "q" },
+      validationRules: [],
+    };
+
+    // if the schema gains a property this fixture does not cover, this fails loudly
+    // rather than silently drifting from validate.ts's knownKeys list
+    expect(Object.keys(rule).sort()).toEqual(Object.keys(properties).sort());
+
+    fs.writeFileSync(
+      path.join(skills, "skill-rules.yaml"),
+      yaml.dump({ version: "1.0", skills: { everything: rule } }),
+      "utf8",
+    );
+
+    const result = execSync(`node "${COMPILED_CLI_PATH}" validate --verbose`, {
+      cwd: tmp,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    expect(result).not.toContain("Unknown field");
+    expect(result).not.toContain("Missing required field");
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 });

--- a/packages/create-auto-loading-claude-skills/tests/document-discovery.test.ts
+++ b/packages/create-auto-loading-claude-skills/tests/document-discovery.test.ts
@@ -171,6 +171,23 @@ describe("DocumentDiscovery class", () => {
       expect(result.content).toBeUndefined();
     });
 
+    it("should detect a lowercase skill.md (case-insensitive, matches discovery)", () => {
+      // otherwise the AI add-skill flow would not see a lowercase skill and could create a
+      // duplicate uppercase SKILL.md beside it on a case-sensitive filesystem
+      const skillDir = path.join(tmpDir, ".claude/skills/lower-existing");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "skill.md"),
+        "---\nname: lower-existing\n---\n# Lowercase",
+        "utf8",
+      );
+
+      const result = discovery.checkExistingSkill("lower-existing");
+
+      expect(result.exists).toBe(true);
+      expect(result.content).toContain("Lowercase");
+    });
+
     it("should detect existing resources (including symlinks)", () => {
       const skillDir = path.join(tmpDir, ".claude/skills/skill-with-resources");
       const resourcesDir = path.join(skillDir, "resources");

--- a/packages/create-auto-loading-claude-skills/tests/hooks/compiled-hooks.test.ts
+++ b/packages/create-auto-loading-claude-skills/tests/hooks/compiled-hooks.test.ts
@@ -9,6 +9,7 @@
  * IMPORTANT: Run `pnpm build` before running these tests
  */
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -145,5 +146,492 @@ describe("Compiled Hooks", () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+  });
+});
+
+/**
+ * Regression: current Claude Code sends `cwd`, not `working_directory`.
+ *
+ * These assertions deliberately check OBSERVABLE OUTPUT, not just `exitCode === 0`.
+ * Every hook catches its errors and exits 0 by design (fail-open), and most print
+ * nothing on failure — so "did not crash" is satisfied by a hook that resolved no
+ * config and did nothing at all. Each hook below is paired with a negative control
+ * (no directory field, no CLAUDE_PROJECT_DIR) proving the assertion is actually
+ * sensitive to directory resolution.
+ */
+describe("Hook payload compatibility (cwd vs working_directory)", () => {
+  let tmpDir: string;
+  // a guaranteed-empty dir for negative controls, so "resolved nothing" is asserted
+  // against a dir with no .claude/skills — not against the ambient process.cwd()
+  let bareCwd: string;
+
+  /** Rules exercising each hook family, so every hook has something observable to emit. */
+  const RULES = `version: "1.0"
+settings:
+  maxSuggestions: 3
+skills:
+  backend-dev-guidelines:
+    type: domain
+    enforcement: suggest
+    priority: high
+    activationStrategy: suggestive
+    description: "Backend API patterns"
+    promptTriggers:
+      keywords:
+        - API
+        - endpoint
+  bash-guard:
+    type: guardrail
+    enforcement: warn
+    priority: critical
+    activationStrategy: suggestive
+    description: "Dangerous shell commands"
+    preToolTriggers:
+      toolName: Bash
+      inputPatterns:
+        - "rm -rf"
+  completion-check:
+    type: workflow
+    enforcement: suggest
+    priority: high
+    activationStrategy: suggestive
+    description: "Verify before claiming done"
+    stopTriggers:
+      keywords:
+        - all tests pass
+`;
+
+  function skillFile(name: string): void {
+    const dir = path.join(tmpDir, ".claude/skills", name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "SKILL.md"),
+      `---\nname: ${name}\ndescription: test\n---\n\n# ${name}\n`,
+      "utf8",
+    );
+  }
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(process.cwd(), ".test-cwd-payload-"));
+    fs.mkdirSync(path.join(tmpDir, ".claude/cache"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".claude/skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude/skills/skill-rules.yaml"),
+      RULES,
+      "utf8",
+    );
+    ["backend-dev-guidelines", "bash-guard", "completion-check"].forEach(skillFile);
+    bareCwd = fs.mkdtempSync(path.join(os.tmpdir(), "bare-cwd-"));
+  });
+
+  afterAll(() => {
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+    if (bareCwd && fs.existsSync(bareCwd)) {
+      fs.rmSync(bareCwd, { recursive: true, force: true });
+    }
+  });
+
+  const NO_PROJECT_DIR = { CLAUDE_PROJECT_DIR: undefined };
+
+  /**
+   * Each case states what the hook must OBSERVABLY do once it has resolved the config.
+   * `dir` is spread into the payload so the same expectation can be driven through
+   * `cwd`, through legacy `working_directory`, and through neither.
+   */
+  const CASES: {
+    hook: string;
+    payload: (dir: Record<string, string>) => Record<string, unknown>;
+    observed: (r: { stdout: string }) => boolean;
+    what: string;
+  }[] = [
+    {
+      hook: "skill-activation-prompt.ts",
+      what: "suggests the matching skill",
+      payload: (dir) => ({
+        ...dir,
+        session_id: "obs-1",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Create an API endpoint for users",
+      }),
+      observed: (r) => r.stdout.includes("backend-dev-guidelines"),
+    },
+    {
+      hook: "skill-activation-json.ts",
+      what: "emits additionalContext naming the skill",
+      payload: (dir) => ({
+        ...dir,
+        session_id: "obs-2",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Create an API endpoint for users",
+      }),
+      observed: (r) => r.stdout.includes("backend-dev-guidelines"),
+    },
+    {
+      hook: "pre-tool-use-validator.ts",
+      what: "matches a preToolTriggers rule against object tool_input",
+      payload: (dir) => ({
+        ...dir,
+        session_id: "obs-3",
+        tool_name: "Bash",
+        tool_input: { command: "rm -rf /tmp/x", description: "cleanup" },
+      }),
+      observed: (r) => r.stdout.includes("bash-guard"),
+    },
+    {
+      hook: "pre-tool-use-validator-json.ts",
+      what: "matches a preToolTriggers rule against object tool_input",
+      payload: (dir) => ({
+        ...dir,
+        session_id: "obs-4",
+        tool_name: "Bash",
+        tool_input: { command: "rm -rf /tmp/x", description: "cleanup" },
+      }),
+      observed: (r) => r.stdout.includes("bash-guard"),
+    },
+    {
+      hook: "stop-validator.ts",
+      what: "raises the completion self-check",
+      payload: (dir) => ({
+        ...dir,
+        session_id: "obs-5",
+        transcript_summary: "all tests pass, we are done here",
+      }),
+      observed: (r) => r.stdout.includes("completion-check"),
+    },
+    {
+      hook: "session-start.ts",
+      what: "reports the skills it loaded",
+      payload: (dir) => ({ ...dir, session_id: "obs-6" }),
+      observed: (r) => r.stdout.includes("3 skills loaded"),
+    },
+  ];
+
+  describe.each(CASES)("$hook", ({ hook, payload, observed, what }) => {
+    it(`${what} — cwd payload`, () => {
+      const result = executeCompiledHook(
+        hook,
+        { ...payload({ cwd: tmpDir }), session_id: `${hook}-cwd` } as never,
+        NO_PROJECT_DIR,
+      );
+      expect(result.stderr).toBe("");
+      expect(observed(result)).toBe(true);
+    });
+
+    it(`${what} — legacy working_directory payload`, () => {
+      const result = executeCompiledHook(
+        hook,
+        {
+          ...payload({ working_directory: tmpDir }),
+          session_id: `${hook}-legacy`,
+        } as never,
+        NO_PROJECT_DIR,
+      );
+      expect(result.stderr).toBe("");
+      expect(observed(result)).toBe(true);
+    });
+
+    it("negative control: emits nothing when the resolved dir has no rules", () => {
+      // proves the assertions above depend on resolution rather than passing vacuously.
+      // Pin the child cwd to a guaranteed-empty dir so the fallback resolves THERE — not
+      // to the ambient process.cwd(), which the assertion would otherwise silently depend on.
+      const result = executeCompiledHook(
+        hook,
+        { ...payload({}), session_id: `${hook}-none` } as never,
+        NO_PROJECT_DIR,
+        bareCwd,
+      );
+      expect(observed(result)).toBe(false);
+    });
+  });
+
+  it("post-tool-use-tracker records the edited file under the resolved project dir", () => {
+    const edited = path.join(tmpDir, "src/api/users.ts");
+    const result = executeCompiledHook(
+      "post-tool-use-tracker.ts",
+      {
+        cwd: tmpDir,
+        session_id: "obs-tracker",
+        tool_name: "Edit",
+        tool_input: { file_path: edited },
+      } as never,
+      NO_PROJECT_DIR,
+    );
+
+    expect(result.stderr).toBe("");
+    // the observable effect is state written under the RESOLVED directory
+    const cacheDir = path.join(tmpDir, ".claude/cache");
+    const written = fs
+      .readdirSync(cacheDir)
+      .filter((f) => f.includes("obs-tracker"));
+    expect(written.length).toBeGreaterThan(0);
+    const state = fs.readFileSync(path.join(cacheDir, written[0]!), "utf8");
+    expect(state).toContain("users.ts");
+  });
+
+  it("CLAUDE_PROJECT_DIR still wins over the payload when both are present", () => {
+    // documents the real production precedence: Claude Code always sets this env var,
+    // so the payload fields are the fallback path, not the primary one
+    const result = executeCompiledHook(
+      "skill-activation-prompt.ts",
+      {
+        cwd: "/nonexistent-dir-that-has-no-rules",
+        session_id: "obs-precedence",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Create an API endpoint for users",
+      } as never,
+      { CLAUDE_PROJECT_DIR: tmpDir },
+    );
+
+    expect(result.stdout).toContain("backend-dev-guidelines");
+  });
+});
+
+/**
+ * End-to-end coverage for user scope through the SHIPPED hooks.
+ *
+ * The unit tests pin ConfigLoader; these pin the composed path that actually runs in a
+ * session — payload -> initHookContext -> ConfigLoader(userScope) -> printed output.
+ * That composed path is the one that could leak a private file into Claude's context.
+ */
+describe("user scope through shipped hooks", () => {
+  let projectDir: string;
+  let homeDir: string;
+
+  const RULE = (name: string, keyword: string) => `version: "1.0"
+skills:
+  ${name}:
+    type: domain
+    enforcement: suggest
+    priority: high
+    activationStrategy: suggestive
+    description: "${name}"
+    promptTriggers:
+      keywords:
+        - ${keyword}
+`;
+
+  function writeSkill(root: string, name: string, body: string): void {
+    const dir = path.join(root, ".claude/skills", name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "SKILL.md"), body, "utf8");
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "userscope-proj-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "userscope-home-"));
+    fs.mkdirSync(path.join(projectDir, ".claude/skills"), { recursive: true });
+    fs.mkdirSync(path.join(homeDir, ".claude/skills"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("suggests a USER-scope skill through the shipped hook", () => {
+    fs.writeFileSync(
+      path.join(homeDir, ".claude/skills/skill-rules.yaml"),
+      RULE("user-only-skill", "deploy"),
+      "utf8",
+    );
+    writeSkill(homeDir, "user-only-skill", "# user only\n");
+
+    const result = executeCompiledHook(
+      "skill-activation-prompt.ts",
+      {
+        cwd: projectDir,
+        session_id: "userscope-1",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "help me deploy this",
+      } as never,
+      { CLAUDE_PROJECT_DIR: undefined, HOME: homeDir, USERPROFILE: homeDir },
+    );
+
+    // fails if userScope is dropped from the template
+    expect(result.stdout).toContain("user-only-skill");
+  });
+
+  it("does NOT read a user-scope SKILL.md that only the PROJECT rules name", () => {
+    // The untrusted-repo scenario: a cloned project's rules claim a skill whose file only
+    // exists under $HOME. `guaranteed` is required here — that is the strategy which
+    // injects file CONTENT; a `suggestive` rule only ever prints the description, so the
+    // assertion would hold even with the vulnerability present.
+    writeSkill(homeDir, "private-notes", "# TOPSECRET user content\n");
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+      `version: "1.0"
+skills:
+  private-notes:
+    type: domain
+    enforcement: suggest
+    priority: high
+    activationStrategy: guaranteed
+    description: "claimed by an untrusted project config"
+    promptTriggers:
+      keywords:
+        - anything
+`,
+      "utf8",
+    );
+
+    const result = executeCompiledHook(
+      "skill-activation-json.ts",
+      {
+        cwd: projectDir,
+        session_id: "userscope-2",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "anything at all",
+      } as never,
+      { CLAUDE_PROJECT_DIR: undefined, HOME: homeDir, USERPROFILE: homeDir },
+    );
+
+    expect(result.stdout).not.toContain("TOPSECRET");
+  });
+
+  it("DOES inject content for a guaranteed skill the user declared (control)", () => {
+    // proves the assertion above is not passing merely because content injection is off
+    fs.writeFileSync(
+      path.join(homeDir, ".claude/skills/skill-rules.yaml"),
+      `version: "1.0"
+skills:
+  user-guaranteed:
+    type: domain
+    enforcement: suggest
+    priority: high
+    activationStrategy: guaranteed
+    description: "declared by the user"
+    promptTriggers:
+      keywords:
+        - anything
+`,
+      "utf8",
+    );
+    writeSkill(homeDir, "user-guaranteed", "# LEGITIMATE user content\n");
+
+    const result = executeCompiledHook(
+      "skill-activation-json.ts",
+      {
+        cwd: projectDir,
+        session_id: "userscope-4",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "anything at all",
+      } as never,
+      { CLAUDE_PROJECT_DIR: undefined, HOME: homeDir, USERPROFILE: homeDir },
+    );
+
+    expect(result.stdout).toContain("LEGITIMATE user content");
+  });
+
+  it("project rules win over user rules of the same name", () => {
+    // `guaranteed` + the json hook injects CONTENT, so the two copies are
+    // distinguishable — asserting the shared NAME could not tell the scopes apart
+    const RULE_GUARANTEED = `version: "1.0"
+skills:
+  shared:
+    type: domain
+    enforcement: suggest
+    priority: high
+    activationStrategy: guaranteed
+    description: "shared"
+    promptTriggers:
+      keywords:
+        - deploy
+`;
+    fs.writeFileSync(
+      path.join(homeDir, ".claude/skills/skill-rules.yaml"),
+      RULE_GUARANTEED,
+      "utf8",
+    );
+    writeSkill(homeDir, "shared", "# USERCOPY\n");
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+      RULE_GUARANTEED,
+      "utf8",
+    );
+    writeSkill(projectDir, "shared", "# PROJECTCOPY\n");
+
+    const result = executeCompiledHook(
+      "skill-activation-json.ts",
+      {
+        cwd: projectDir,
+        session_id: "userscope-3",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "help me deploy this",
+      } as never,
+      { CLAUDE_PROJECT_DIR: undefined, HOME: homeDir, USERPROFILE: homeDir },
+    );
+
+    expect(result.stdout).toContain("PROJECTCOPY");
+    expect(result.stdout).not.toContain("USERCOPY");
+  });
+});
+
+/**
+ * Security regression: a `warn`-enforcement guardrail must INFORM without granting the
+ * tool call. It previously routed through an "allow" builder, so the moment `inputPatterns`
+ * actually matched object `tool_input`, a warning silently authorized the tool.
+ */
+describe("warn enforcement does not grant permission", () => {
+  let projectDir: string;
+  let homeDir: string;
+
+  const WARN_RULES = `version: "1.0"
+skills:
+  warnguard:
+    type: guardrail
+    enforcement: warn
+    priority: high
+    activationStrategy: suggestive
+    description: "warns on rm -rf"
+    preToolTriggers:
+      toolName: Bash
+      inputPatterns:
+        - "rm -rf"
+`;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "warn-proj-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "warn-home-"));
+    fs.mkdirSync(path.join(homeDir, ".claude", "skills"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, ".claude", "skills", "warnguard"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/warnguard/SKILL.md"),
+      "---\nname: warnguard\ndescription: warns\n---\n# warnguard\n",
+    );
+    fs.writeFileSync(
+      path.join(projectDir, ".claude/skills/skill-rules.yaml"),
+      WARN_RULES,
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("emits additionalContext with NO permissionDecision on a matching warn rule", () => {
+    const result = executeCompiledHook(
+      "pre-tool-use-validator-json.ts",
+      {
+        cwd: projectDir,
+        session_id: "warn-1",
+        tool_name: "Bash",
+        tool_input: { command: "rm -rf /tmp/x", description: "cleanup" },
+      } as never,
+      { CLAUDE_PROJECT_DIR: undefined, HOME: homeDir, USERPROFILE: homeDir },
+    );
+
+    // the guardrail fired (matched the object tool_input)...
+    expect(result.stdout).toContain("warnguard");
+    // ...but must NOT have granted permission
+    const payload = JSON.parse(result.stdout || "{}") as {
+      hookSpecificOutput?: { permissionDecision?: string };
+    };
+    expect(payload.hookSpecificOutput?.permissionDecision).toBeUndefined();
+    expect(result.stdout).not.toContain('"allow"');
   });
 });

--- a/packages/create-auto-loading-claude-skills/tests/hooks/helpers.ts
+++ b/packages/create-auto-loading-claude-skills/tests/hooks/helpers.ts
@@ -1,6 +1,7 @@
 // Test helper utilities for hook testing
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import fs from "fs";
+import os from "os";
 import path from "path";
 
 /**
@@ -21,9 +22,62 @@ export interface HookResult {
 export interface HookEvent {
   prompt?: string;
   session_id: string;
-  working_directory: string;
+  /** Current Claude Code payloads send `cwd`; older ones sent `working_directory`. */
+  cwd?: string;
+  working_directory?: string;
+  transcript_path?: string;
+  hook_event_name?: string;
   tool_name?: string;
   tool_input?: Record<string, unknown>;
+}
+
+/** Created once per process — a fresh dir per call leaked hundreds per suite run. */
+let hermeticHomeDir: string | null = null;
+function sharedHermeticHome(): string {
+  if (!hermeticHomeDir) {
+    hermeticHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "hook-home-"));
+    const dir = hermeticHomeDir;
+    process.once("exit", () => {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best effort — a leftover temp dir is not worth failing a test run
+      }
+    });
+  }
+  return hermeticHomeDir;
+}
+
+/**
+ * Build a child env with HOME/USERPROFILE pinned to a throwaway dir.
+ *
+ * Every hook template merges user scope (~/.claude/skills), so without this a developer's
+ * real global rules leak into results and the suite behaves differently on CI.
+ * Pass `HOME`/`USERPROFILE` through `overrides` to seed user scope deliberately.
+ */
+function hermeticEnv(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string> {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+
+  env.HOME = sharedHermeticHome();
+  env.USERPROFILE = env.HOME;
+
+  // Keep tool caches pointing at the REAL home. Repointing HOME alone made
+  // `pnpm exec tsx` re-download corepack on every call (~4s each, and a hard failure on
+  // a network-isolated runner) because its cache lives under the home directory.
+  const realHome = process.env.HOME ?? process.env.USERPROFILE;
+  if (realHome) {
+    env.COREPACK_HOME ??= path.join(realHome, ".cache", "node", "corepack");
+    env.npm_config_cache ??= path.join(realHome, ".npm");
+    env.XDG_CACHE_HOME ??= path.join(realHome, ".cache");
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+  return env;
 }
 
 /**
@@ -46,10 +100,7 @@ export function executeTemplateHook(
   try {
     const result = execSync(`pnpm exec tsx ${hookPath}`, {
       input,
-      env: {
-        ...process.env,
-        ...env,
-      },
+      env: hermeticEnv(env),
       encoding: "utf8",
     });
 
@@ -101,10 +152,7 @@ export function executeNodeScript(
   try {
     const result = execSync(`node "${scriptPath}"`, {
       input,
-      env: {
-        ...process.env,
-        ...env,
-      },
+      env: hermeticEnv(env),
       encoding: "utf8",
     });
 
@@ -126,7 +174,10 @@ export function executeNodeScript(
 export function executeCompiledHook(
   hookName: string,
   event: HookEvent,
-  env: Record<string, string> = {},
+  /** Pass a key with `undefined` to UNSET it (e.g. CLAUDE_PROJECT_DIR) for the child. */
+  env: Record<string, string | undefined> = {},
+  /** Pin the child's working directory — the last-resort fallback in initHookContext. */
+  cwd?: string,
 ): HookResult {
   // compiled hooks are in dist/src/templates/hooks/*.js
   const jsHookName = hookName.replace(/\.ts$/, ".js");
@@ -142,27 +193,24 @@ export function executeCompiledHook(
     );
   }
 
-  const input = JSON.stringify(event);
+  // explicit undefined removes the var from the child env (spawn would otherwise
+  // stringify it), which is how a test asserts behavior with CLAUDE_PROJECT_DIR absent
+  const childEnv = hermeticEnv(env);
 
-  try {
-    const result = execSync(`node ${hookPath}`, {
-      input,
-      env: {
-        ...process.env,
-        ...env,
-      },
-      encoding: "utf8",
-    });
+  // spawnSync, not execSync: execSync returns only stdout, so a helper that reported
+  // stderr as "" made every `expect(stderr).toBe("")` unfalsifiable
+  const result = spawnSync("node", [hookPath], {
+    input: JSON.stringify(event),
+    env: childEnv,
+    cwd,
+    encoding: "utf8",
+  });
 
-    return { stdout: result, stderr: "", exitCode: 0 };
-  } catch (error) {
-    const execError = error as ExecSyncError;
-    return {
-      stdout: execError.stdout ?? "",
-      stderr: execError.stderr ?? "",
-      exitCode: execError.status ?? 1,
-    };
-  }
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    exitCode: result.status ?? 1,
+  };
 }
 
 /**
@@ -188,11 +236,7 @@ export function executeGeneratedHook(
   try {
     const stdout = execSync(`node ${hookPath}`, {
       input,
-      env: {
-        ...process.env,
-        CLAUDE_PROJECT_DIR: projectDir,
-        ...env,
-      },
+      env: hermeticEnv({ CLAUDE_PROJECT_DIR: projectDir, ...env }),
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/packages/create-auto-loading-claude-skills/tests/utils/skill-paths.test.ts
+++ b/packages/create-auto-loading-claude-skills/tests/utils/skill-paths.test.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveSkillFile, skillExists } from "../../src/utils/skill-paths.js";
+
+describe("skillExists (shared SSOT predicate for sync + validate)", () => {
+  let skillsDir: string;
+
+  beforeEach(() => {
+    skillsDir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-paths-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(skillsDir, { recursive: true, force: true });
+  });
+
+  function makeSkill(name: string, file: string): void {
+    fs.mkdirSync(path.join(skillsDir, name), { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, name, file), "# skill");
+  }
+
+  it("is true when SKILL.md exists", () => {
+    makeSkill("alpha", "SKILL.md");
+    expect(skillExists(skillsDir, "alpha")).toBe(true);
+  });
+
+  it("is true when the lowercase skill.md exists", () => {
+    // sync discovers with a case-insensitive glob, so this must count as present —
+    // otherwise a synced lowercase skill is reported orphaned and dropped as stale
+    makeSkill("beta", "skill.md");
+    expect(skillExists(skillsDir, "beta")).toBe(true);
+  });
+
+  it("is false when the directory exists but has no SKILL.md", () => {
+    fs.mkdirSync(path.join(skillsDir, "gamma"), { recursive: true });
+    expect(skillExists(skillsDir, "gamma")).toBe(false);
+  });
+
+  it("is false for a name that does not exist", () => {
+    expect(skillExists(skillsDir, "nope")).toBe(false);
+  });
+});
+
+describe("resolveSkillFile", () => {
+  let skillsDir: string;
+
+  beforeEach(() => {
+    skillsDir = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-skill-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(skillsDir, { recursive: true, force: true });
+  });
+
+  it("returns the uppercase path when SKILL.md exists", () => {
+    fs.mkdirSync(path.join(skillsDir, "a"), { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, "a", "SKILL.md"), "x");
+    expect(resolveSkillFile(skillsDir, "a")).toBe(
+      path.join(skillsDir, "a", "SKILL.md"),
+    );
+  });
+
+  it("returns the lowercase path when only skill.md exists", () => {
+    fs.mkdirSync(path.join(skillsDir, "b"), { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, "b", "skill.md"), "x");
+    expect(resolveSkillFile(skillsDir, "b")).toBe(
+      path.join(skillsDir, "b", "skill.md"),
+    );
+  });
+
+  it("returns null when neither exists", () => {
+    fs.mkdirSync(path.join(skillsDir, "c"), { recursive: true });
+    expect(resolveSkillFile(skillsDir, "c")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Corrects a set of interlocking defects in the skill-activation engine, surfaced and driven to sign-off across an 11-round multi-model review gauntlet (code-reviewer + test-quality-assessor + Codex/GPT-5.2, unanimous SHIP on the final tree). Every fix is mutation-verified.

**Versioning:** runtime `@satoshibits/claude-skill-runtime` is a **minor** bump; CLI `@satoshibits/create-auto-loading-claude-skills` is a **major** bump (breaking changes in `validate` and `sync`). Two changesets are included.

## Runtime (`@satoshibits/claude-skill-runtime`)

- **`preToolTriggers.inputPatterns` never matched** — `tool_input` is an object, coerced to `"[object Object]"`. Now matches per string-leaf value (anchors preserved, key names and non-string leaves excluded), memoized and cycle-guarded.
- **Opt-in user-scope rules** (`~/.claude/skills`) merged beneath project rules, with content resolution **isolated to the declaring scope** so an untrusted project config cannot read a `$HOME` file; path traversal rejected.
- Hook directory resolves the current `cwd` payload with `working_directory`/`CLAUDE_PROJECT_DIR`/`process.cwd()` fallbacks.
- Skill resolution accepts both `SKILL.md` and `skill.md` (case-insensitive, matching discovery) so a lowercase skill no longer silently fails to load.
- New `buildPreToolUseContextOutput`: advisory output with **no** `permissionDecision`.

## CLI (`@satoshibits/create-auto-loading-claude-skills`) — BREAKING

- **A `warn` guardrail no longer emits `permissionDecision: "allow"`** — it silently granted the tool once `inputPatterns` began matching. It now informs only.
- **`validate` fails on real errors** (missing required fields, bad enum, malformed `skills:` block) so it can gate CI; adds `-y/--yes` for unattended `--fix`; refuses to auto-fix a malformed `skills:` block rather than discarding it; no longer crashes on absent/scalar/list `skills` or null rule entries.
- **`sync`** reads project skills from `.claude/skills/` only (not `.claude/commands/`, which no reader could resolve); stops copying personal skills into project configs; drops entries whose `SKILL.md` is genuinely gone while keeping transiently-unparseable synced skills sync-owned; fixes a permanent-stale deadlock; `sync-status` applies the same scope rule.
- All user-skill existence/resolution funnels through a single `resolveSkillFile` predicate (`utils/skill-paths.ts`).
- Hook templates accept the current `cwd` payload; all seven opt into user scope; the `PreToolUse` text template drops its misleading "BLOCKED" banner.

> Note: `init` registers only `UserPromptSubmit`, `PostToolUse`, `Stop` — not `PreToolUse`/`SessionStart` — so `preToolTriggers` and `session-start` need manual `settings.json` wiring.

## Tests

168 runtime + 351 CLI passing; both packages lint (0 errors) and typecheck clean. Hook assertions check observable output with mutation-verified negative controls; a runtime unit guard pins the warn-must-not-grant invariant independent of any built binary.

## Release

Merging this PR opens a changesets **"Version Packages" PR** (bumps versions + changelogs); merging *that* publishes via `ci:publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWdZJqidQKY91k3EX5Qpuu